### PR TITLE
Feature/dcc 4248 gv mutation impact

### DIFF
--- a/dcc-portal-api/src/main/java/org/icgc/dcc/portal/repository/BrowserRepository.java
+++ b/dcc-portal-api/src/main/java/org/icgc/dcc/portal/repository/BrowserRepository.java
@@ -22,6 +22,7 @@ import static org.elasticsearch.index.query.FilterBuilders.andFilter;
 import static org.elasticsearch.index.query.FilterBuilders.orFilter;
 import static org.elasticsearch.index.query.FilterBuilders.rangeFilter;
 import static org.elasticsearch.index.query.FilterBuilders.termFilter;
+import static org.elasticsearch.index.query.FilterBuilders.nestedFilter;
 import static org.elasticsearch.index.query.QueryBuilders.filteredQuery;
 
 import java.util.List;
@@ -65,8 +66,8 @@ public class BrowserRepository {
   }
 
   public SearchResponse getMutation(String segmentId, Long start, Long stop, List<String> consequenceTypes,
-      List<String> projectFilters) {
-    val filter = getMutationFilter(segmentId, start, stop, consequenceTypes, projectFilters);
+      List<String> projectFilters, List<String> impactFilters) {
+    val filter = getMutationFilter(segmentId, start, stop, consequenceTypes, projectFilters, impactFilters);
 
     return execute("Browser Mutation Request", (request) -> request
         .setTypes(MUTATION)
@@ -141,8 +142,8 @@ public class BrowserRepository {
   }
 
   public SearchResponse getMutationHistogram(Long interval, String segmentId, Long start, Long stop,
-      List<String> consequenceTypes, List<String> projectFilters) {
-    val filter = getMutationFilter(segmentId, start, stop, consequenceTypes, projectFilters);
+      List<String> consequenceTypes, List<String> projectFilters, List<String> impactFilters) {
+    val filter = getMutationFilter(segmentId, start, stop, consequenceTypes, projectFilters, impactFilters);
 
     val histogramAggs = AggregationBuilders.histogram("hf")
         .field("chromosome_start")
@@ -170,13 +171,18 @@ public class BrowserRepository {
    * Builds a FilterBuilder with only the applicable filter values.
    */
   private static FilterBuilder getMutationFilter(String segmentId, Long start, Long stop, List<String> consequenceTypes,
-      List<String> projectFilters) {
+      List<String> projectFilters, List<String> impactFilters) {
 
     val filter = andFilter(
         termFilter("chromosome", segmentId),
         rangeFilter("chromosome_start").lte(stop),
         rangeFilter("chromosome_end").gte(start));
 
+    if (impactFilters != null && !impactFilters.isEmpty()) {
+      val impactFilter = getImpactFilter(impactFilters);
+      filter.add(impactFilter);
+    }
+    
     if (consequenceTypes != null) {
       val consequenceFilter = getConsequenceFilter(consequenceTypes);
       filter.add(consequenceFilter);
@@ -255,6 +261,20 @@ public class BrowserRepository {
     }
 
     return projectFilter;
+  }
+  
+  /**
+   * Builds a FilterBuilder for Functional Impact.
+   * This filter is special as Transcripts are nested documents. 
+   */
+  private static FilterBuilder getImpactFilter(List<String> impacts) {
+    val impactFilter = orFilter();
+    for (val impact: impacts) {
+      impactFilter.add(FilterBuilders.termFilter("transcript.functional_impact_prediction_summary", impact));
+    }
+    
+    val nested = nestedFilter("transcript", impactFilter);
+    return nested;
   }
 
 }

--- a/dcc-portal-api/src/main/java/org/icgc/dcc/portal/resource/BrowserResource.java
+++ b/dcc-portal-api/src/main/java/org/icgc/dcc/portal/resource/BrowserResource.java
@@ -51,6 +51,7 @@ public class BrowserResource {
     private static final String RESOURCE = "resource";
     private static final String BIOTYPE = "biotype";
     private static final String CONSEQUENCE_TYPE = "consequence_type";
+    private static final String FUNCTIONAL_IMPACT = "functional_impact";
   }
 
   /**
@@ -67,8 +68,9 @@ public class BrowserResource {
       @QueryParam(ParameterNames.INTERVAL) String interval,
       @QueryParam(ParameterNames.RESOURCE) String resource,
       @QueryParam(ParameterNames.BIOTYPE) String bioType,
-      @QueryParam(ParameterNames.CONSEQUENCE_TYPE) String consequenceType) {
-    return getData(segment, histogram, dataType, interval, resource, bioType, consequenceType);
+      @QueryParam(ParameterNames.CONSEQUENCE_TYPE) String consequenceType,
+      @QueryParam(ParameterNames.FUNCTIONAL_IMPACT) String functionalImpact) {
+    return getData(segment, histogram, dataType, interval, resource, bioType, consequenceType, functionalImpact);
   }
 
   /**
@@ -85,8 +87,9 @@ public class BrowserResource {
       @QueryParam(ParameterNames.INTERVAL) String interval,
       @QueryParam(ParameterNames.RESOURCE) String resource,
       @QueryParam(ParameterNames.BIOTYPE) String bioType,
-      @QueryParam(ParameterNames.CONSEQUENCE_TYPE) String consequenceType) {
-    return getData(segment, histogram, dataType, interval, resource, bioType, consequenceType);
+      @QueryParam(ParameterNames.CONSEQUENCE_TYPE) String consequenceType,
+      @QueryParam(ParameterNames.FUNCTIONAL_IMPACT) String functionalImpact) {
+    return getData(segment, histogram, dataType, interval, resource, bioType, consequenceType, functionalImpact);
   }
 
   /**
@@ -94,7 +97,7 @@ public class BrowserResource {
    */
   @SneakyThrows
   String getData(String segment, String histogram, String dataType,
-      String interval, String resource, String bioType, String consequenceType) {
+      String interval, String resource, String bioType, String consequenceType, String functionalImpact) {
 
     checkRequest(isBlank(resource), "'resource' parameter is required but missing.");
 
@@ -114,6 +117,7 @@ public class BrowserResource {
     queryMap.put(ParameterNames.RESOURCE, resource);
     queryMap.put(ParameterNames.BIOTYPE, bioType);
     queryMap.put(ParameterNames.CONSEQUENCE_TYPE, consequenceType);
+    queryMap.put(ParameterNames.FUNCTIONAL_IMPACT, functionalImpact);
 
     return MAPPER
         .writeValueAsString(isHistogram ? browserService.getHistogram(queryMap) : browserService.getRecords(queryMap));

--- a/dcc-portal-api/src/main/java/org/icgc/dcc/portal/service/BrowserService.java
+++ b/dcc-portal-api/src/main/java/org/icgc/dcc/portal/service/BrowserService.java
@@ -140,21 +140,27 @@ public class BrowserService {
   private List<Object> getSegmentGene(String segmentId, Long start, Long stop, Map<String, String> queryMap) {
     val biotypeValue = queryMap.get("biotype");
     val biotypes = parseList(biotypeValue);
+    
+    val impactFilterValue = queryMap.get("functional_impact");
+    val impactFilters = parseList(impactFilterValue);
 
     val withTranscripts = nullToEmpty(queryMap.get("dataType")).equals("withTranscripts");
 
-    val searchResponse = browserRepository.getGene(segmentId, start, stop, biotypes, withTranscripts);
+    val searchResponse = browserRepository.getGene(segmentId, start, stop, biotypes, withTranscripts, impactFilters);
     return BrowserParsers.parseGenes(segmentId, start, stop, biotypes, withTranscripts, searchResponse);
   }
 
   private List<Object> getHistogramSegmentGene(String segmentId, Long start, Long stop, Map<String, String> queryMap) {
     val biotypeValue = queryMap.get("biotype");
     val biotypes = parseList(biotypeValue);
+    
+    val impactFilterValue = queryMap.get("functional_impact");
+    val impactFilters = parseList(impactFilterValue);
 
     val intervalValue = queryMap.get("interval");
     val interval = intervalValue != null ? Math.round(Double.parseDouble(intervalValue)) : 0;
 
-    val searchResponse = browserRepository.getGeneHistogram(interval, segmentId, start, stop, biotypes);
+    val searchResponse = browserRepository.getGeneHistogram(interval, segmentId, start, stop, biotypes, impactFilters);
     return BrowserParsers.parseHistogramGene(segmentId, start, stop, interval, biotypes, searchResponse);
   }
 

--- a/dcc-portal-api/src/main/java/org/icgc/dcc/portal/service/BrowserService.java
+++ b/dcc-portal-api/src/main/java/org/icgc/dcc/portal/service/BrowserService.java
@@ -107,8 +107,12 @@ public class BrowserService {
 
     val projectFilterValue = queryMap.get("consequence_type");
     val projectFilters = parseList(projectFilterValue);
+    
+    val impactFilterValue = queryMap.get("functional_impact");
+    val impactFilters = parseList(impactFilterValue);
 
-    val searchResponse = browserRepository.getMutation(segmentId, start, stop, consequenceTypes, projectFilters);
+    val searchResponse = browserRepository.getMutation(segmentId, start, stop, consequenceTypes, projectFilters, impactFilters);
+    
     return BrowserParsers.parseMutations(segmentId, start, stop, consequenceTypes, projectFilters, searchResponse);
   }
 
@@ -120,11 +124,15 @@ public class BrowserService {
     val projectFilterValue = queryMap.get("consequence_type");
     val projectFilters = parseList(projectFilterValue);
 
+    val impactFilterValue = queryMap.get("functional_impact");
+    val impactFilters = parseList(impactFilterValue);
+
     val intervalValue = queryMap.get("interval");
     val interval = intervalValue != null ? Math.round(Double.parseDouble(intervalValue)) : 0;
 
     val searchResponse =
-        browserRepository.getMutationHistogram(interval, segmentId, start, stop, consequenceTypes, projectFilters);
+        browserRepository.getMutationHistogram(interval, segmentId, start, stop, consequenceTypes, projectFilters,
+            impactFilters);
     return BrowserParsers.parseHistogramMutation(segmentId, start, stop, interval, consequenceTypes, projectFilters,
         searchResponse);
   }

--- a/dcc-portal-ui/app/scripts/genomemaps/js/viewer.js
+++ b/dcc-portal-ui/app/scripts/genomemaps/js/viewer.js
@@ -615,6 +615,7 @@ angular.module('icgc.modules.genomeviewer').directive('gvembed', function (GMSer
           maxLabelRegionSize: 10000000,
           height: 100,
           autoHeight: true,
+          functional_impact: _.get(LocationService.filters(), 'mutation.functionalImpact.is', ''),
           renderer: icgcGeneOverviewRenderer,
           dataAdapter: new IcgcGeneAdapter({
             resource: 'gene',
@@ -633,6 +634,7 @@ angular.module('icgc.modules.genomeviewer').directive('gvembed', function (GMSer
           maxLabelRegionSize: 10000000,
           minTranscriptRegionSize: 300000,
           height: 100,
+          functional_impact: _.get(LocationService.filters(), 'mutation.functionalImpact.is', ''),
           renderer: new GeneRenderer({
           tooltipContainerID: '#genomic',
             handlers: {
@@ -739,6 +741,13 @@ angular.module('icgc.modules.genomeviewer').directive('gvembed', function (GMSer
             'mutation.functionalImpact.not', tracks.icgcMutationsTrack.functional_impact);
           tracks.icgcMutationsTrack.dataAdapter.clearData();
           tracks.icgcMutationsTrack.draw();
+          
+          tracks.icgcGeneTrack.functional_impact = _.get(LocationService.filters(),
+            'mutation.functionalImpact.is', '');
+          tracks.icgcGeneTrack.functional_impact = _.get(LocationService.filters(),
+            'mutation.functionalImpact.not', tracks.icgcMutationsTrack.functional_impact);
+          tracks.icgcGeneTrack.dataAdapter.clearData();
+          tracks.icgcGeneTrack.draw();
         });
         scope.$on('gv:set:region', function (e, params) {
           genomeViewer.setRegion(params);

--- a/dcc-portal-ui/app/scripts/genomemaps/js/viewer.js
+++ b/dcc-portal-ui/app/scripts/genomemaps/js/viewer.js
@@ -126,7 +126,6 @@ angular.module('icgc.modules.genomeviewer').controller('GenomeViewerController',
     document.addEventListener('mozfullscreenchange', _fullscreenHandler);
     document.addEventListener('fullscreenchange', _fullscreenHandler);
 
-
     $scope.$on('$destroy', function() {
       document.removeEventListener('webkitfullscreenchange');
       document.removeEventListener('mozfullscreenchange');
@@ -134,10 +133,6 @@ angular.module('icgc.modules.genomeviewer').controller('GenomeViewerController',
     });
 
   };
-
-
-
-
 
 });
 
@@ -178,15 +173,8 @@ angular.module('icgc.modules.genomeviewer').directive('genomeViewer', function (
                 regionHistoryButton:false,
                 speciesButton:false,
                 chromosomesButton:false,
-//                  karyotypeButton:false,
-//                  chromosomeButton:false,
-//                  regionButton:false,
-//                  zoomControl:false,
                 windowSizeControl:false,
                 positionControl:false,
-//                  moveControl:false,
-//                  autoheightButton:false,
-//                  compactButton:false,
                 searchControl:false
               }
             },
@@ -322,7 +310,6 @@ angular.module('icgc.modules.genomeviewer').directive('genomeViewer', function (
 
         genomeViewer.addTrack(tracks.icgcGeneTrack);
 
-
         tracks.icgcMutationsTrack = new IcgcMutationTrack({
           title: 'ICGC Mutations',
           minHistogramRegionSize: 10000,
@@ -366,8 +353,6 @@ angular.module('icgc.modules.genomeviewer').directive('genomeViewer', function (
           height: 8,
           histogramColor: 'orange',
           handlers: {
-            //'feature:mouseover': function (e) {
-            //},
             'feature:click': function (e) {
               scope.$apply(function () {
                 $location.path('/mutations/' + e.feature.id).search({});
@@ -386,8 +371,6 @@ angular.module('icgc.modules.genomeviewer').directive('genomeViewer', function (
           })
         });
 
-
-
         genomeViewer.addTrack(tracks.icgcMutationsTrack);
         /** End add tracks **/
 
@@ -398,7 +381,6 @@ angular.module('icgc.modules.genomeviewer').directive('genomeViewer', function (
         genomeViewer.chromosomePanel.hide();
         GenomeViewerController.initFullScreenHandler(genomeViewer);
       }
-
 
       scope.$watch('[genes, mutations, tab]', function (params) {
         var genes, mutations, tab;
@@ -448,13 +430,6 @@ angular.module('icgc.modules.genomeviewer').directive('genomeViewer', function (
 
         }
       }, true);
-      
-
-
-
-
-      
-
 
       scope.$on('gv:set:region', function (e, params) {
         if (genomeViewer) {
@@ -484,7 +459,8 @@ angular.module('icgc.modules.genomeviewer').directive('genomeViewer', function (
   };
 });
 
-angular.module('icgc.modules.genomeviewer').directive('gvembed', function (GMService, $location, gvConstants) {
+angular.module('icgc.modules.genomeviewer').directive('gvembed', function (GMService, $location,
+  LocationService, gvConstants) {
   return {
     restrict: 'E',
     replace: true,
@@ -495,9 +471,6 @@ angular.module('icgc.modules.genomeviewer').directive('gvembed', function (GMSer
     link: function (scope, element, attrs, GenomeViewerController) {
       var genomeViewer, navigationBar, tracks = {};
       var availableSpecies;
-
-
-
 
       function setup(regionObj) {
         regionObj.start = parseInt(regionObj.start);
@@ -520,15 +493,8 @@ angular.module('icgc.modules.genomeviewer').directive('gvembed', function (GMSer
               regionHistoryButton:false,
               speciesButton:false,
               chromosomesButton:false,
-//                karyotypeButton:false,
-//                chromosomeButton:false,
-//                regionButton:false,
-//                zoomControl:false,
               windowSizeControl:false,
               positionControl:false,
-//                moveControl:false,
-//                autoheightButton:false,
-//                compactButton:false,
               searchControl:false
             }
           },
@@ -691,13 +657,12 @@ angular.module('icgc.modules.genomeviewer').directive('gvembed', function (GMSer
         });
         genomeViewer.addTrack(tracks.icgcGeneTrack);
 
-
         tracks.icgcMutationsTrack = new IcgcMutationTrack({
           title: 'ICGC Mutations',
           minHistogramRegionSize: 10000,
           maxLabelRegionSize: 3000,
           height: 100,
-
+          functional_impact: _.get(LocationService.filters(), 'mutation.functionalImpact.is', ''),
           renderer: new FeatureRenderer({
             tooltipContainerID: '#genomic',
             label: function (f) {
@@ -767,10 +732,14 @@ angular.module('icgc.modules.genomeviewer').directive('gvembed', function (GMSer
 
         GenomeViewerController.initFullScreenHandler(genomeViewer);
 
-        //genomeViewer.toggleAutoHeight(true);
-
-
-
+        scope.$on('$locationChangeSuccess', function () {
+          tracks.icgcMutationsTrack.functional_impact = _.get(LocationService.filters(),
+            'mutation.functionalImpact.is', '');
+          tracks.icgcMutationsTrack.functional_impact = _.get(LocationService.filters(),
+            'mutation.functionalImpact.not', tracks.icgcMutationsTrack.functional_impact);
+          tracks.icgcMutationsTrack.dataAdapter.clearData();
+          tracks.icgcMutationsTrack.draw();
+        });
         scope.$on('gv:set:region', function (e, params) {
           genomeViewer.setRegion(params);
         });
@@ -788,7 +757,6 @@ angular.module('icgc.modules.genomeviewer').directive('gvembed', function (GMSer
             genomeViewer.destroy();
           }
         });
-
       }
 
       attrs.$observe('region', function (region) {

--- a/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-gene-adapter.js
+++ b/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-gene-adapter.js
@@ -151,8 +151,6 @@ IcgcGeneAdapter.prototype.getData = function (args) {
     }
   }
 
-//    var segmentObj = {chromosome: params.chromosome, start: start, end: end};
-
   var webServiceCallBack = function (data, segment) {
     var jsonResponse = data[0];
 

--- a/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-gene-adapter.js
+++ b/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-gene-adapter.js
@@ -121,7 +121,8 @@ IcgcGeneAdapter.prototype.getData = function (args) {
     interval: args.interval,
     chromosome: args.chromosome,
     resource: args.resource,
-    transcript: args.transcript
+    transcript: args.transcript,
+    functional_impact: args.functional_impact
   }
 
   var start = (args.start < 1) ? 1 : args.start;
@@ -273,6 +274,11 @@ IcgcGeneAdapter.prototype._callWebService = function (segmentString, callback, p
     interval: params.interval,
     dataType: params.dataType
   };
+  
+  if (params.functional_impact) {
+    callParams.functional_impact = params.functional_impact;
+  }
+  
   var url = this.host + '/' + this.resource + this._getQuery(callParams);
   $.ajax({
     type: 'GET',

--- a/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-gene-track.js
+++ b/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-gene-track.js
@@ -162,7 +162,8 @@ IcgcGeneTrack.prototype.draw = function () {
       histogramLogarithm: this.histogramLogarithm,
       histogramMax: this.histogramMax,
       interval: this.interval,
-      transcript: this.transcript
+      transcript: this.transcript,
+      functional_impact: this.functional_impact
     });
 
     //this.invalidZoomText.setAttribute('visibility', 'hidden');
@@ -195,7 +196,8 @@ IcgcGeneTrack.prototype.move = function (disp) {
         end: this.svgCanvasLeftLimit,
         histogram: this.histogram,
         interval: this.interval,
-        transcript: this.transcript
+        transcript: this.transcript,
+        functional_impact: this.functional_impact
       });
       this.svgCanvasLeftLimit = parseInt(this.svgCanvasLeftLimit - this.svgCanvasOffset, 10);
     }
@@ -207,7 +209,8 @@ IcgcGeneTrack.prototype.move = function (disp) {
         end: parseInt(this.svgCanvasRightLimit + this.svgCanvasOffset, 10),
         histogram: this.histogram,
         interval: this.interval,
-        transcript: this.transcript
+        transcript: this.transcript,
+        functional_impact: this.functional_impact
       });
       this.svgCanvasRightLimit = parseInt(this.svgCanvasRightLimit + this.svgCanvasOffset, 10);
     }

--- a/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-mutation-adapter.js
+++ b/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-mutation-adapter.js
@@ -234,7 +234,7 @@ IcgcMutationAdapter.prototype._callWebService = function (segmentString, callbac
     resource: this.resource,
     histogram: params.histogram,
     interval: params.interval,
-    exclude: params.exclude,
+    exclude: params.exclude
   };
   
   if (params.functional_impact) {

--- a/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-mutation-adapter.js
+++ b/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-mutation-adapter.js
@@ -236,8 +236,7 @@ IcgcMutationAdapter.prototype._callWebService = function (segmentString, callbac
     interval: params.interval,
     exclude: params.exclude,
   };
-
-  console.log(params.functional_impact);
+  
   if (params.functional_impact) {
     callParams.functional_impact = params.functional_impact;
   }

--- a/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-mutation-adapter.js
+++ b/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-mutation-adapter.js
@@ -27,9 +27,7 @@ function IcgcMutationAdapter(args) {
 
   this.host = window.$icgcApp.getQualifiedHost() + '/api/browser';
   this.gzip = true;
-
   this.params = {};
-
 
   this.setSpecies = function(species) {
     this.species = species;
@@ -122,7 +120,8 @@ IcgcMutationAdapter.prototype.getData = function (args) {
     interval: args.interval,
     chromosome: args.chromosome,
     resource: args.resource,
-    transcript: args.transcript
+    transcript: args.transcript,
+    functional_impact: args.functional_impact
   }
 
   var start = (args.start < 1) ? 1 : args.start;
@@ -150,8 +149,6 @@ IcgcMutationAdapter.prototype.getData = function (args) {
     }
   }
 
-//    var segmentObj = {chromosome: params.chromosome, start: start, end: end};
-
   var webServiceCallBack = function (data, segment) {
     var jsonResponse = data[0];
     if (params.histogram == true) {
@@ -167,22 +164,9 @@ IcgcMutationAdapter.prototype.getData = function (args) {
         }
       }
     }
-//        for (var i = 0; i < jsonResponse.length; i++) {
-//            var feature = jsonResponse[i];
-//        if(_this.filters) {
-//             if(_.contains(activeMutationTypes, feature.mutationType)) {
-//                    _this.featureCache.putFeaturesByRegion(feature, segmentObj, 'snp', dataType);
-//                }
-//        }else {
-//            _this.featureCache.putFeaturesByRegion(feature, segmentObj, 'snp', dataType);
-//        }
-//        }
-    /**/
-//        if (params.histogram == true) {
-//            _this.featureCache.putFeaturesByRegion(jsonResponse, segment, 'snp', dataType);
-//        } else {
+
     var fc = _this.featureCache._getChunk(segment.start);
-    //var k = segment.chromosome + ':' + fc;
+
     if (_this.featureCache.cache[key] == null || _this.featureCache.cache[key][dataType] == null) {
       // Define a feature type where genome viewer does not have a default for - the reason
       // is that genome viewer will by default clobber your own custom settings if you do.
@@ -205,7 +189,6 @@ IcgcMutationAdapter.prototype.getData = function (args) {
   var updateStart = true;
   var updateEnd = true;
   if (chunks.length > 0) {
-    //		console.log(chunks);
 
     for (var i = 0; i < chunks.length; i++) {
 
@@ -234,7 +217,6 @@ IcgcMutationAdapter.prototype.getData = function (args) {
         updateEnd = true;
       }
     }
-    //		console.log(querys);
     console.time(_this.resource + ' get and save ' + rnd);
     for (query in queries) {
       this._callWebService(queries[query], webServiceCallBack, params);
@@ -247,17 +229,18 @@ IcgcMutationAdapter.prototype.getData = function (args) {
 };
 
 IcgcMutationAdapter.prototype._callWebService = function (segmentString, callback, params) {
-//    ?segment=' + segmentString + '&chromosome=13&resource=mutation&dataType=data
-//     http://localhost:9001/api/browser/mutation?segment=17:7480000-7669999&resource=mutation&histogram=true&interval=2000
-//        url : 'http://imedina:8080/api/genes?segment='+segmentString+'&chromosome=13&resource=gene&dataType=data',
-//        url : 'http://imedina:8080/api/genes?filters={"gene":{"gene_location":["chr'+segmentString+'"]}}',
   var callParams = {
     segment: segmentString,
     resource: this.resource,
     histogram: params.histogram,
     interval: params.interval,
-    exclude: params.exclude
+    exclude: params.exclude,
   };
+
+  console.log(params.functional_impact);
+  if (params.functional_impact) {
+    callParams.functional_impact = params.functional_impact;
+  }
 
   var url = this.host + '/' + this.resource + this._getQuery(callParams);
     console.log(url);

--- a/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-mutation-track.js
+++ b/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-mutation-track.js
@@ -169,7 +169,6 @@ IcgcMutationTrack.prototype.draw = function () {
 
 IcgcMutationTrack.prototype.move = function (disp) {
   var _this = this;
-//    trackSvg.position = _this.region.center();
   _this.region.center();
   var pixelDisplacement = disp * _this.pixelBase;
   this.pixelPosition -= pixelDisplacement;
@@ -240,7 +239,6 @@ IcgcMutationTrack.prototype._getFeaturesByChunks = function (response) {
         featureLastChunk = this.dataAdapter.featureCache._getChunk(feature.end);
         for (var f = featureFirstChunk; f <= featureLastChunk; f++) {
           var fkey = chromosome + ':' + f;
-          //console.log(fkey + dataType)
           if (this.chunksDisplayed[fkey + dataType] === true) {
             displayed = true;
             break;

--- a/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-mutation-track.js
+++ b/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-mutation-track.js
@@ -160,11 +160,10 @@ IcgcMutationTrack.prototype.draw = function () {
       start: this.region.start - this.svgCanvasOffset * 2,
       end: this.region.end + this.svgCanvasOffset * 2,
       histogram: this.histogram,
-      interval: this.interval
+      interval: this.interval,
+      functional_impact: this.functional_impact
     });
-    //this.invalidZoomText.setAttribute('visibility', 'hidden');
   } else {
-    //this.invalidZoomText.setAttribute('visibility', 'visible');
   }
 };
 
@@ -248,17 +247,6 @@ IcgcMutationTrack.prototype._getFeaturesByChunks = function (response) {
           }
         }
         if (!displayed) {
-          //apply filter
-          // if(filters != null) {
-          //		var pass = true;
-          // 		for(filter in filters) {
-          // 			pass = pass && filters[filter](feature);
-          //			if(pass == false) {
-          //				break;
-          //			}
-          // 		}
-          //		if(pass) features.push(feature);
-          // } else {
           features.push(feature);
         }
       }

--- a/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-mutation-track.js
+++ b/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-mutation-track.js
@@ -188,7 +188,8 @@ IcgcMutationTrack.prototype.move = function (disp) {
         start: parseInt(this.svgCanvasLeftLimit - this.svgCanvasOffset),
         end: this.svgCanvasLeftLimit,
         histogram: this.histogram,
-        interval: this.interval
+        interval: this.interval,
+        functional_impact: this.functional_impact
       });
       this.svgCanvasLeftLimit = parseInt(this.svgCanvasLeftLimit - this.svgCanvasOffset);
     }
@@ -199,7 +200,8 @@ IcgcMutationTrack.prototype.move = function (disp) {
         start: this.svgCanvasRightLimit,
         end: parseInt(this.svgCanvasRightLimit + this.svgCanvasOffset, 10),
         histogram: this.histogram,
-        interval: this.interval
+        interval: this.interval,
+        functional_impact: this.functional_impact
       });
       this.svgCanvasRightLimit = parseInt(this.svgCanvasRightLimit + this.svgCanvasOffset, 10);
     }


### PR DESCRIPTION
Mutation Impact filter on gene entity page now modifies the mutation histogram in the genome viewer. 

Cleaned up spacing, comments, and logging in viewer/adapter code for improved readability. 