### PR TITLE
Bugfix: / in url of "download/info/{release}" was being escaped DCC-4949

### DIFF
--- a/dcc-portal-ui/app/scripts/repository/js/services.js
+++ b/dcc-portal-ui/app/scripts/repository/js/services.js
@@ -221,7 +221,7 @@
   module.service('RepositoryService', function ($filter, RestangularNoCache) {
 
     this.folder = function (path) {
-      return RestangularNoCache.one('download', 'info' + path)
+      return RestangularNoCache.one('download/info', path.replace(/^\//, ''))
               .get();
     };
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/743976/16670715/8f9acbf6-4469-11e6-84c5-f0eeebaaa4ff.png)
