### PR TITLE
DCC-4886-Donor-Clinical-Data-Overflow

### DIFF
--- a/dcc-portal-ui/app/styles/_modules/_tables.scss
+++ b/dcc-portal-ui/app/styles/_modules/_tables.scss
@@ -95,6 +95,7 @@ $table-th-fixed-width: 200px;
 
     td {
       white-space: normal;
+      word-break:break-all;
     }
   }
 


### PR DESCRIPTION
A new CSS rule added to break continues words overflowing out of parent. 
