### PR TITLE
Fix "region overview" button in genome viewer

### DIFF
--- a/dcc-portal-ui/app/scripts/genes/js/genes.js
+++ b/dcc-portal-ui/app/scripts/genes/js/genes.js
@@ -84,12 +84,14 @@
     return {
       restrict: 'A',
       link: function (scope, $element) {
-        var mutationObservers = createMutationObservers($element.find('.dynamic-height').get());
-        scope.$on('$destroy', function () {
-          mutationObservers.forEach(function (observer) {
-            observer.disconnect();
+        if (jQuery(window.location.hash).length) {
+          var mutationObservers = createMutationObservers($element.find('.dynamic-height').get());
+          scope.$on('$destroy', function () {
+            mutationObservers.forEach(function (observer) {
+              observer.disconnect();
+            });
           });
-        });
+        }
       }
     };
   });

--- a/dcc-portal-ui/app/scripts/genomemaps/js/header.js
+++ b/dcc-portal-ui/app/scripts/genomemaps/js/header.js
@@ -45,7 +45,7 @@ angular.module('icgc.modules.genomeviewer.header').controller('GenomeViewerHeade
   $scope.panels = {
     karyotype: false,
     chromosome: false,
-    regionOverview: true
+    overviewTrackList: true
   };
 
   $scope.reset = function (e) {

--- a/dcc-portal-ui/app/scripts/genomemaps/views/header.html
+++ b/dcc-portal-ui/app/scripts/genomemaps/views/header.html
@@ -6,8 +6,8 @@
     <button class="t_button" ng-class="{'t_button__active': panels.chromosome}"
             ng-click="togglePanel('chromosome')">Chromosome
     </button>
-    <button class="t_button" ng-class="{'t_button__active': panels.regionOverview}"
-            ng-click="togglePanel('regionOverview')">Region Overview
+    <button class="t_button" ng-class="{'t_button__active': panels.overviewTrackList}"
+            ng-click="togglePanel('overviewTrackList')">Region Overview
     </button>
 </span>
 <span data-ng-if="options.autofit">


### PR DESCRIPTION
Seems to have been renamed to `overviewTrackList` in genome-viewer.js
