### PR TITLE
Survival graph updates

### DIFF
--- a/dcc-portal-ui/app/scripts/phenotype/js/phenotype.js
+++ b/dcc-portal-ui/app/scripts/phenotype/js/phenotype.js
@@ -143,7 +143,7 @@
                 height: 380,
                 urlPath: $location.url(),
                 setLabelFunc: function (id) {
-                  return _.find(setData, {id: id}).name;
+                  return 'S' + (setData.indexOf(_.find(setData, {id: id})) + 1);
                 },
               });
               var $canvasContainer = $element.find('.mini-venn-canvas');

--- a/dcc-portal-ui/app/scripts/phenotype/styles/phenotype.result.scss
+++ b/dcc-portal-ui/app/scripts/phenotype/styles/phenotype.result.scss
@@ -1,16 +1,21 @@
 .mini-venn-canvas {
   svg {
     cursor: pointer;
-    transform: scale(1.3);
+    transform: scale(1.2);
     & > * {
       pointer-events: none;
     }
   }
-  text:not(.venn-count) {
-    display: none;
-  }
-  .venn-count {
+
+  text {
       font-size: 22px; 
+  }
+
+  &.only-two {
+    overflow: hidden;
+    svg {
+      transform: scale(1.2) translateY(30px);
+    }
   }
 }
 

--- a/dcc-portal-ui/app/scripts/phenotype/views/phenotype.result.html
+++ b/dcc-portal-ui/app/scripts/phenotype/views/phenotype.result.html
@@ -50,8 +50,9 @@
                         data-ng-repeat="donorSetId in setIds"
                     >
                         <div>
-                            <div style="color:{{seriesColours[$index]}}">
-                                {{setMap[donorSetId].name}}
+                            <div>
+                                <span style="color:{{seriesColours[$index]}}">{{setMap[donorSetId].name}}</span>
+                                <sub>( S{{($index + 1)}} )</sub>
                             </div>
                             <small>
                                 Donor count: {{setMap[setIds[$index]].count | number}}
@@ -133,8 +134,16 @@
             </tbody>
         </table>
                 </div>
-                <div ng-show="intersectionsExist" class="col-md-3">
-                    <div class="mini-venn-canvas"></div>
+                <div
+                    ng-show="intersectionsExist &&
+                        (survivalAnalysisDataSets.overall.length > 2 ||
+                        survivalAnalysisDataSets.overall.length < 4 ) "
+                    class="col-md-3"
+                >
+                    <div
+                        class="mini-venn-canvas"
+                        ng-class="{ 'only-two': survivalAnalysisDataSets.overall.length === 2 }"
+                    ></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Changes based on comments from Vincent
- Add "S1", "S2", "S3" labels for sets
  ![image](https://cloud.githubusercontent.com/assets/743976/16853300/d41b7f8a-49d9-11e6-9961-53e8a090d02c.png)
- Align venn diagram for only 2 sets
  ![image](https://cloud.githubusercontent.com/assets/743976/16853316/e630ffc4-49d9-11e6-9c39-03b60abb43df.png)
- Hide venn diagram when there are more than 3 sets
