### PR TITLE
'Analysis' icon added to the breadcrumb

### DIFF
--- a/dcc-portal-ui/app/scripts/analysis/views/analysis.analysis.launcher.html
+++ b/dcc-portal-ui/app/scripts/analysis/views/analysis.analysis.launcher.html
@@ -1,11 +1,16 @@
 <section>
 <div data-ng-if="!analysisId" data-ng-controller="NewAnalysisController as NAC" class="analysis">
     <div style="font-size:1.25rem">
+        <span class="action-toolbar" data-ng-show="NAC.analysisType !== null">
+          <span class="action-item"  style="border:none">
+            <i class="icon-beaker"></i><a href="" data-ng-click="NAC.analysisType = null">Analysis</a>
+          </span>                  
+        </span>
         <span data-ng-show="NAC.analysisType !== null">&gt;</span>
         <span data-ng-show="NAC.analysisType !== null">
-            Select {{NAC.analysisType === 'enrichment'?'set':'sets'}} for 
-            <strong>{{NAC.analysisName(NAC.analysisType)}}</strong>
-        </span>
+          Select {{NAC.analysisType === 'enrichment'?'set':'sets'}} for 
+          <strong>{{NAC.analysisName(NAC.analysisType)}}</strong>
+        </span>      
     </div>
 
     <div data-ng-show="NAC.analysisType === null">

--- a/dcc-portal-ui/app/scripts/analysis/views/analysis.analysis.launcher.html
+++ b/dcc-portal-ui/app/scripts/analysis/views/analysis.analysis.launcher.html
@@ -10,7 +10,7 @@
         <span data-ng-show="NAC.analysisType !== null">
           Select {{NAC.analysisType === 'enrichment'?'set':'sets'}} for 
           <strong>{{NAC.analysisName(NAC.analysisType)}}</strong>
-        </span>      
+        </span>
     </div>
 
     <div data-ng-show="NAC.analysisType === null">

--- a/dcc-portal-ui/app/scripts/analysis/views/analysis.analysis.launcher.html
+++ b/dcc-portal-ui/app/scripts/analysis/views/analysis.analysis.launcher.html
@@ -2,7 +2,7 @@
 <div data-ng-if="!analysisId" data-ng-controller="NewAnalysisController as NAC" class="analysis">
     <div style="font-size:1.25rem">
         <span class="action-toolbar" data-ng-show="NAC.analysisType !== null">
-          <span class="action-item"  style="border:none">
+          <span class="action-item">
             <i class="icon-beaker"></i><a href="" data-ng-click="NAC.analysisType = null">Analysis</a>
           </span>                  
         </span>


### PR DESCRIPTION
Analysis icon in the path "> Select set for Enrichment Analysis" has been added. So when user clicks on it, it comes back to the previous page. 
I would like to have @phuongmy input on it so please hold off on merging this. 
