### PR TITLE
Add option to use prod API for UI dev

### DIFF
--- a/dcc-portal-ui/Gruntfile.js
+++ b/dcc-portal-ui/Gruntfile.js
@@ -25,6 +25,17 @@ var mountFolder = function (connect, dir) {
 
 var proxySnippet = require('grunt-connect-proxy/lib/utils').proxyRequest;
 var HOSTNAME = 'local.dcc.icgc.org';
+var apiProxySettings = process.env.API_SOURCE === 'production' ? {
+      context: '/api',
+      host: 'dcc.icgc.org',
+      port: 443,
+      https: true
+    } : {
+      context: '/api',
+      host: 'localhost',
+      port: 8080,
+      https: false
+    }
 
 // # Globbing
 // for performance reasons we're only matching one level down:
@@ -124,12 +135,7 @@ module.exports = function (grunt) {
         hostname: HOSTNAME
       },
       proxies: [
-        {
-          context: '/api',
-          host: 'localhost',
-          port: 8080,
-          https: false
-        }
+        apiProxySettings
       ],
       livereload: {
         options: {

--- a/dcc-portal-ui/Gruntfile.js
+++ b/dcc-portal-ui/Gruntfile.js
@@ -35,7 +35,7 @@ var apiProxySettings = process.env.API_SOURCE === 'production' ? {
       host: 'localhost',
       port: 8080,
       https: false
-    }
+    };
 
 // # Globbing
 // for performance reasons we're only matching one level down:

--- a/dcc-portal-ui/package.json
+++ b/dcc-portal-ui/package.json
@@ -12,7 +12,8 @@
     "unsethost": "hostile remove local.dcc.icgc.org",
     "checkhost": "node tasks/checkDns.js",
     "predev": "npm run checkhost",
-    "dev": "grunt server"
+    "dev": "grunt server",
+    "dev:prodapi": "API_SOURCE=production npm run dev"
   },
   "devDependencies": {
     "autoprefixer": "6.3.7",

--- a/dcc-portal-ui/package.json
+++ b/dcc-portal-ui/package.json
@@ -23,7 +23,7 @@
     "grunt": "0.4.5",
     "grunt-bower-install-simple": "1.2.3",
     "grunt-concurrent": "0.3.0",
-    "grunt-connect-proxy": "0.2.0",
+    "grunt-connect-proxy": "git+https://github.com/drewzboto/grunt-connect-proxy.git#f798bbd31b76b039a392b8f1bca55b310a7ac5c9",
     "grunt-contrib-clean": "0.4.1",
     "grunt-contrib-coffee": "0.7.0",
     "grunt-contrib-compass": "0.3.0",


### PR DESCRIPTION
Added `dev:prodapi` npm task. Use `npm run dev:prodapi` to run. This will use the production API, useful sometimes for when only doing front end UI work

Had to update grunt-connect-proxy to an unpublished commit. Current npm release is stale, (more than a year old) and has a bug where proxying https results in an ECONNRESET error
