### PR TITLE
DCC 5032 Bootstrap 404 error fix

### DIFF
--- a/dcc-portal-ui/app/index.html
+++ b/dcc-portal-ui/app/index.html
@@ -192,8 +192,7 @@
 <script src="bower_components/showdown/src/showdown.js"></script>
 <script src="bower_components/showdown/src/extensions/table.js"></script>
 <script src="bower_components/x2js/xml2json.js"></script>
-<script src="bower_components/dist/js/bootstrap.min.js"></script>
-<script src="bower_components/bootstrap/js/dropdown.js"></script>
+<script src="bower_components/bootstrap/dist/js/bootstrap.min.js"></script>
 <script src="scripts/ui/js/table2CSV.js"></script>
 <script src="vendor/scripts/invariant.js"></script>
 <!-- endbuild -->


### PR DESCRIPTION
Updated bootstrap.js path to fetch file from the proper folder. Removed dropdown.js as bootstrap js already includes dropdown functionality. 
