### PR TITLE
DCC 4223 - Spinner shows on loading

### DIFF
--- a/dcc-portal-ui/app/scripts/facets/views/donorfacet.html
+++ b/dcc-portal-ui/app/scripts/facets/views/donorfacet.html
@@ -59,7 +59,7 @@
                placeholder="{{ placeholder }}"
                data-types="{{ types }}"
                data-suggest="tags"/>
-        <i class="t_suggest__embedded t_suggest__embedded__right  icon-spin icon-spinner" data-ng-show='isBusy'></i>
+        <i class="t_suggest__embedded t_suggest__embedded__right  icon-spin icon-spinner" data-ng-if='isBusy'></i>
         <i class="t_suggest__embedded t_suggest__embedded__right t_suggest__embedded__clear icon-cancel"
            data-ng-click="query='';quick()" data-ng-show='query && !isBusy'></i>
     </li>

--- a/dcc-portal-ui/app/scripts/facets/views/genetags.html
+++ b/dcc-portal-ui/app/scripts/facets/views/genetags.html
@@ -77,7 +77,7 @@
                placeholder="{{ placeholder }}"
                data-types="{{ types }}"
                data-suggest="tags"/>
-        <i class="t_suggest__embedded t_suggest__embedded__right  icon-spin icon-spinner" data-ng-show='isBusy'></i>
+        <i class="t_suggest__embedded t_suggest__embedded__right  icon-spin icon-spinner" data-ng-if='isBusy'></i>
         <i class="t_suggest__embedded t_suggest__embedded__right t_suggest__embedded__clear icon-cancel"
            data-ng-click="query='';quick()" data-ng-show='query && !isBusy'></i>
     </li>

--- a/dcc-portal-ui/app/scripts/facets/views/gotags.html
+++ b/dcc-portal-ui/app/scripts/facets/views/gotags.html
@@ -36,7 +36,7 @@
                placeholder="{{ placeholder }}"
                data-types="{{ types }}"
                data-suggest="tags"/>
-        <i class="t_suggest__embedded t_suggest__embedded__right  icon-spin icon-spinner" data-ng-show='isBusy'></i>
+        <i class="t_suggest__embedded t_suggest__embedded__right  icon-spin icon-spinner" data-ng-if='isBusy'></i>
         <i class="t_suggest__embedded t_suggest__embedded__right t_suggest__embedded__clear icon-cancel"
            data-ng-click="query='';quick()" data-ng-show='query && !isBusy'></i>
     </li>

--- a/dcc-portal-ui/app/scripts/facets/views/pathwaytags.html
+++ b/dcc-portal-ui/app/scripts/facets/views/pathwaytags.html
@@ -35,7 +35,7 @@
                placeholder="{{ placeholder }}"
                data-types="{{ types }}"
                data-suggest="tags"/>
-        <i class="t_suggest__embedded t_suggest__embedded__right  icon-spin icon-spinner" data-ng-show='isBusy'></i>
+        <i class="t_suggest__embedded t_suggest__embedded__right  icon-spin icon-spinner" data-ng-if='isBusy'></i>
         <i class="t_suggest__embedded t_suggest__embedded__right t_suggest__embedded__clear icon-cancel"
            data-ng-click="query='';quick()" data-ng-show='query && !isBusy'></i>
     </li>

--- a/dcc-portal-ui/app/scripts/facets/views/tags.html
+++ b/dcc-portal-ui/app/scripts/facets/views/tags.html
@@ -64,7 +64,7 @@
                placeholder="{{ placeholder }}"
                data-types="{{ types }}"
                data-suggest="tags"/>
-        <i class="t_suggest__embedded t_suggest__embedded__right  icon-spin icon-spinner" data-ng-show='isBusy'></i>
+        <i class="t_suggest__embedded t_suggest__embedded__right  icon-spin icon-spinner" data-ng-if='isBusy'></i>
         <i class="t_suggest__embedded t_suggest__embedded__right t_suggest__embedded__clear icon-cancel"
            data-ng-click="query='';quick()" data-ng-show='query && !isBusy'></i>
     </li>


### PR DESCRIPTION
Replaced ngShow with ngIf. The spinner code won't be in DOM until user starts typing something. Making sure not to show it when page loads. 
