### PR TITLE
Fixed bower fail (I think)

### DIFF
--- a/dcc-portal-ui/.gitignore
+++ b/dcc-portal-ui/.gitignore
@@ -4,3 +4,4 @@ app/styles/bootstrap.css
 report/
 app/scripts/common/js/pql/pqlparser.js
 target/
+test-bower*

--- a/dcc-portal-ui/Gruntfile.js
+++ b/dcc-portal-ui/Gruntfile.js
@@ -517,11 +517,6 @@ module.exports = function (grunt) {
     'karma'
   ]);
 
-  grunt.registerTask('test-bower', [
-    'ICGC-setBuildEnv:production',
-    'bower-install',
-    ]);
-
   grunt.registerTask('build', [
     'ICGC-setBuildEnv:production',
     'clean:dist',

--- a/dcc-portal-ui/Gruntfile.js
+++ b/dcc-portal-ui/Gruntfile.js
@@ -517,6 +517,11 @@ module.exports = function (grunt) {
     'karma'
   ]);
 
+  grunt.registerTask('test-bower', [
+    'ICGC-setBuildEnv:production',
+    'bower-install',
+    ]);
+
   grunt.registerTask('build', [
     'ICGC-setBuildEnv:production',
     'clean:dist',

--- a/dcc-portal-ui/app/index.html
+++ b/dcc-portal-ui/app/index.html
@@ -159,7 +159,7 @@
 <script src="bower_components/lodash/lodash.js"></script>
 
 <!-- Angular Libs -->
-<script src="bower_components/angularjs/angular.js"></script>
+<script src="bower_components/angular/angular.js"></script>
 <script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
 <script src="bower_components/angular-animate/angular-animate.js"></script>
 <script src="bower_components/angular-cookies/angular-cookies.js"></script>

--- a/dcc-portal-ui/bower.json
+++ b/dcc-portal-ui/bower.json
@@ -27,7 +27,7 @@
     "tests"
   ],
   "dependencies": {
-    "angularjs": "1.5.7",
+    "angular": "1.5.7",
     "angular-sanitize": "1.4.11",
     "angular-animate": "1.4.11",
     "angular-cookies": "1.4.11",

--- a/dcc-portal-ui/bower.json
+++ b/dcc-portal-ui/bower.json
@@ -59,7 +59,7 @@
     "angular-scenario": "1.4.11"
   },
   "resolutions": {
-    "angular": "1.5.7",
+    "angular": "~1.5.7",
     "lodash": "3.10.1"
   }
 }

--- a/dcc-portal-ui/karma.conf.js
+++ b/dcc-portal-ui/karma.conf.js
@@ -9,7 +9,7 @@ module.exports = function(config){
       // include relevant Angular files and libs
       'app/bower_components/jquery/dist/jquery.js',
       'app/bower_components/lodash/lodash.js',
-      'app/bower_components/angularjs/angular.js',
+      'app/bower_components/angular/angular.js',
       'app/bower_components/angular-sanitize/angular-sanitize.js',
       'app/bower_components/angular-animate/angular-animate.js',
       'app/bower_components/angular-cookies/angular-cookies.js',

--- a/dcc-portal-ui/package.json
+++ b/dcc-portal-ui/package.json
@@ -13,7 +13,8 @@
     "checkhost": "node tasks/checkDns.js",
     "predev": "npm run checkhost",
     "dev": "grunt server",
-    "dev:prodapi": "API_SOURCE=production npm run dev"
+    "dev:prodapi": "API_SOURCE=production npm run dev",
+    "test-bower": "rm -rf app/bower_components/ && rm -rf ~/.cache/bower/ && grunt test-bower --verbose && cat app/bower_components/angular/bower.json | grep version"
   },
   "devDependencies": {
     "autoprefixer": "6.3.7",

--- a/dcc-portal-ui/package.json
+++ b/dcc-portal-ui/package.json
@@ -14,7 +14,7 @@
     "predev": "npm run checkhost",
     "dev": "grunt server",
     "dev:prodapi": "API_SOURCE=production npm run dev",
-    "test-bower": "rm -rf app/bower_components/ && rm -rf ~/.cache/bower/ && grunt test-bower --verbose && cat app/bower_components/angular/bower.json | grep version"
+    "test-bower": "rm -rf app/bower_components/ && rm -rf ~/.cache/bower/ && bower install -V 2>&1 | tee test-bower-$(date +%Y%m%d%H%M%S).txt && cat app/bower_components/angular/bower.json | grep version"
   },
   "devDependencies": {
     "autoprefixer": "6.3.7",


### PR DESCRIPTION
Switched from `angularjs` to `angular`

I believe this might have been the source of our build errors. We were installing both `angularjs` (our own explicit dependency) and `angular` (the one that our dependencies depend on). They refer to the same library but are treated as separate and can have differing versions. We had set a resolution to `angularjs`, but that did not affect conflicts on `angular`. We are now switched to depending on and setting a resolution for `angular`.

Also added the `test-bower` task to npm, which will 
- delete bower_components and local cache
- run bower install in verbose mode
- save output to a timestamped logfile 
- log out which version of angular was installed

I have _not_ updated any dependencies
