### PR TITLE
Allow tooltips to be local to components/directives. Add to survival graph

### DIFF
--- a/dcc-portal-ui/app/scripts/survivalanalysis/js/survival-analysis.js
+++ b/dcc-portal-ui/app/scripts/survivalanalysis/js/survival-analysis.js
@@ -246,7 +246,7 @@
           xDomain: state.xDomain,
           height: isFullScreen() && ( window.innerHeight - 100 ),
           onMouseEnterDonor: function (event, donor) {
-            $scope.$emit('tooltip::show', {
+            $scope.$broadcast('tooltip::show', {
               element: event.target,
               text: tipTemplate({
                 donor: _.extend(
@@ -261,7 +261,7 @@
             });
           },
           onMouseLeaveDonor: function () {
-            $scope.$emit('tooltip::hide');
+            $scope.$broadcast('tooltip::hide');
           },
           onClickDonor: function (e, donor) {
             window.open('/donors/'+donor.id, '_blank');

--- a/dcc-portal-ui/app/scripts/survivalanalysis/views/survival-analysis.html
+++ b/dcc-portal-ui/app/scripts/survivalanalysis/views/survival-analysis.html
@@ -48,4 +48,8 @@
     
   </div>
 
+  <tooltip-control
+    is-local="true"
+  ></tooltip-control>
+
 </div>

--- a/dcc-portal-ui/app/scripts/ui/js/tooltip.js
+++ b/dcc-portal-ui/app/scripts/ui/js/tooltip.js
@@ -29,6 +29,7 @@
       restrict: 'E',
       replace: true,
       scope: {
+        isLocal: '<'
       },
       templateUrl: 'template/tooltip.html',
       link: function (scope, element) {
@@ -79,7 +80,7 @@
           }
         }
 
-        $rootScope.$on('tooltip::show', function(evt, params) {
+        function handleShow(evt, params) {
           scope.$apply(function() {
             if (params.text) {
               scope.html = $sce.trustAsHtml(params.text);
@@ -98,13 +99,14 @@
               $window.onmousemove = function(e){
                 if(element.hasClass('sticky')){
                   var position = calculateAbsoluteCoordinates(scope.placement, params.element, {
-                    left: e.pageX,
-                    top: e.pageY - (scope.placement === 'top' ? 8 : 0),
+                    left: e.pageX - element.parent().offset().left,
+                    top:  e.pageY - (scope.placement === 'top' ? 8 : 0) - element.parent().offset().top,
                     width: 10,
                     height: -6
                   });
                   element.css('top', position.top);
                   element.css('left', position.left);
+                  // console.log(element.parent().get(0));
                 }
               };
             }
@@ -114,12 +116,17 @@
             element.css('left', position.left);
             element.removeClass('sticky');
           }
-        });
-        $rootScope.$on('tooltip::hide', function() {
+        }
+
+        function handleHide () {
           element.css('visibility', 'hidden');
           element.css('top', -999);
           element.css('left', -999);
-        });
+        }
+
+        var scopeToListenOn = scope.isLocal ? scope : $rootScope;
+        scopeToListenOn.$on('tooltip::show', handleShow);
+        scopeToListenOn.$on('tooltip::hide', handleHide);
       }
     };
   });


### PR DESCRIPTION
Allows tooltips to be displayed on homepage
Reuses the tooltip-controller directive

Added `isLocal` prop to tooltip-controller
When true, it will not listen on $rootScope, but instead on `scope`

Components using a local tooltip-controller will broadcast instead of emit `tooltip::show` and `tooltip::hide`. Function signatures remain the same.
