### PR TITLE
Add local `<tooltip-control/>`s

### DIFF
--- a/dcc-portal-ui/app/scripts/survivalanalysis/js/survival-analysis.js
+++ b/dcc-portal-ui/app/scripts/survivalanalysis/js/survival-analysis.js
@@ -246,7 +246,7 @@
           xDomain: state.xDomain,
           height: isFullScreen() && ( window.innerHeight - 100 ),
           onMouseEnterDonor: function (event, donor) {
-            $scope.$emit('tooltip::show', {
+            $scope.$broadcast('tooltip::show', {
               element: event.target,
               text: tipTemplate({
                 donor: _.extend(
@@ -261,7 +261,7 @@
             });
           },
           onMouseLeaveDonor: function () {
-            $scope.$emit('tooltip::hide');
+            $scope.$broadcast('tooltip::hide');
           },
           onClickDonor: function (e, donor) {
             window.open('/donors/'+donor.id, '_blank');

--- a/dcc-portal-ui/app/scripts/survivalanalysis/js/survival-analysis.js
+++ b/dcc-portal-ui/app/scripts/survivalanalysis/js/survival-analysis.js
@@ -246,22 +246,31 @@
           xDomain: state.xDomain,
           height: isFullScreen() && ( window.innerHeight - 100 ),
           onMouseEnterDonor: function (event, donor) {
-            $scope.$broadcast('tooltip::show', {
-              element: event.target,
-              text: tipTemplate({
-                donor: _.extend(
-                  { isCensored: _.includes(ctrl.censoredStatuses,donor.status) },
-                  donor
-                ),
-                labels: ctrl.tipLabels,
-                unit: 'days'
-              }),
-              placement: 'right',
-              sticky: true
+            // $scope.$broadcast('tooltip::show', {
+            $scope.$apply(function () {
+              ctrl.tooltipParams = {
+                isVisible: true,
+                element: event.target,
+                text: tipTemplate({
+                  donor: _.extend(
+                    { isCensored: _.includes(ctrl.censoredStatuses,donor.status) },
+                    donor
+                  ),
+                  labels: ctrl.tipLabels,
+                  unit: 'days'
+                }),
+                placement: 'right',
+                sticky: true
+              }
             });
           },
           onMouseLeaveDonor: function () {
-            $scope.$broadcast('tooltip::hide');
+            // $scope.$broadcast('tooltip::hide');
+            $scope.$apply(function () {
+              ctrl.tooltipParams = {
+                isVisible: false
+              };
+            });
           },
           onClickDonor: function (e, donor) {
             window.open('/donors/'+donor.id, '_blank');

--- a/dcc-portal-ui/app/scripts/survivalanalysis/js/survival-analysis.js
+++ b/dcc-portal-ui/app/scripts/survivalanalysis/js/survival-analysis.js
@@ -246,7 +246,6 @@
           xDomain: state.xDomain,
           height: isFullScreen() && ( window.innerHeight - 100 ),
           onMouseEnterDonor: function (event, donor) {
-            // $scope.$broadcast('tooltip::show', {
             $scope.$apply(function () {
               ctrl.tooltipParams = {
                 isVisible: true,
@@ -261,11 +260,10 @@
                 }),
                 placement: 'right',
                 sticky: true
-              }
+              };
             });
           },
           onMouseLeaveDonor: function () {
-            // $scope.$broadcast('tooltip::hide');
             $scope.$apply(function () {
               ctrl.tooltipParams = {
                 isVisible: false

--- a/dcc-portal-ui/app/scripts/survivalanalysis/views/survival-analysis.html
+++ b/dcc-portal-ui/app/scripts/survivalanalysis/views/survival-analysis.html
@@ -50,6 +50,7 @@
 
   <tooltip-control
     is-local="true"
+    params="ctrl.tooltipParams"
   ></tooltip-control>
 
 </div>

--- a/dcc-portal-ui/app/scripts/survivalanalysis/views/survival-analysis.html
+++ b/dcc-portal-ui/app/scripts/survivalanalysis/views/survival-analysis.html
@@ -48,4 +48,8 @@
     
   </div>
 
+  <tooltip-control
+    is-local="true"
+  ></tooltip-control>
+
 </div>

--- a/dcc-portal-ui/app/scripts/ui/js/tooltip.js
+++ b/dcc-portal-ui/app/scripts/ui/js/tooltip.js
@@ -24,7 +24,7 @@
    * Centralized tooltip directive. There should be only one per application
    * This act as the tooltip "server" that waits for tooltip events
    */
-  module.directive('tooltipControl', function ($position, $rootScope, $sce, $window) {
+  module.directive('tooltipControl', function ($position, $rootScope, $sce) {
     return {
       restrict: 'E',
       replace: true,
@@ -100,7 +100,7 @@
                 if(element.hasClass('sticky')){
                   var position = calculateAbsoluteCoordinates(scope.placement, params.element, {
                     left: e.pageX - (scope.isLocal ? $parent.offset().left : 0),
-                    top:  e.pageY - (scope.placement === 'top' ? 8 : 0) - (scope.isLocal ? $parent.offset().top : 0),
+                    top: e.pageY - (scope.placement === 'top' ? 8 : 0) - (scope.isLocal ? $parent.offset().top : 0),
                     width: 10,
                     height: -6
                   });
@@ -133,7 +133,7 @@
             if (!newParams) {
               return;
             } else if (newParams.isVisible) {
-              handleShow(null, newParams)
+              handleShow(null, newParams);
             } else {
               handleHide();
             }

--- a/dcc-portal-ui/app/scripts/ui/js/tooltip.js
+++ b/dcc-portal-ui/app/scripts/ui/js/tooltip.js
@@ -29,6 +29,7 @@
       restrict: 'E',
       replace: true,
       scope: {
+        isLocal: '<'
       },
       templateUrl: 'template/tooltip.html',
       link: function (scope, element) {
@@ -79,7 +80,7 @@
           }
         }
 
-        $rootScope.$on('tooltip::show', function(evt, params) {
+        function handleShow(evt, params) {
           scope.$apply(function() {
             if (params.text) {
               scope.html = $sce.trustAsHtml(params.text);
@@ -98,13 +99,14 @@
               $window.onmousemove = function(e){
                 if(element.hasClass('sticky')){
                   var position = calculateAbsoluteCoordinates(scope.placement, params.element, {
-                    left: e.pageX,
-                    top: e.pageY - (scope.placement === 'top' ? 8 : 0),
+                    left: e.pageX - element.parent().offset().left,
+                    top:  e.pageY - (scope.placement === 'top' ? 8 : 0) - element.parent().offset().top,
                     width: 10,
                     height: -6
                   });
                   element.css('top', position.top);
                   element.css('left', position.left);
+                  // console.log(element.parent().get(0));
                 }
               };
             }
@@ -114,12 +116,17 @@
             element.css('left', position.left);
             element.removeClass('sticky');
           }
-        });
-        $rootScope.$on('tooltip::hide', function() {
+        }
+
+        function handleHide () {
           element.css('visibility', 'hidden');
           element.css('top', -999);
           element.css('left', -999);
-        });
+        }
+
+        var scopeToListenOn = scope.isLocal ? scope : $rootScope;
+        scopeToListenOn.$on('tooltip::show', handleShow);
+        scopeToListenOn.$on('tooltip::hide', handleHide);
       }
     };
   });

--- a/dcc-portal-ui/app/scripts/ui/js/tooltip.js
+++ b/dcc-portal-ui/app/scripts/ui/js/tooltip.js
@@ -93,19 +93,19 @@
 
           if(params.sticky){
             element.addClass('sticky');
+            var $parent = element.parent();
 
-            if(!$window.onmousemove){
-              $window.onmousemove = function(e){
+            if(!$parent.get(0).onmousemove){
+              $parent.get(0).onmousemove = function(e){
                 if(element.hasClass('sticky')){
                   var position = calculateAbsoluteCoordinates(scope.placement, params.element, {
-                    left: e.pageX - element.parent().offset().left,
-                    top:  e.pageY - (scope.placement === 'top' ? 8 : 0) - element.parent().offset().top,
+                    left: e.pageX - (scope.isLocal ? $parent.offset().left : 0),
+                    top:  e.pageY - (scope.placement === 'top' ? 8 : 0) - (scope.isLocal ? $parent.offset().top : 0),
                     width: 10,
                     height: -6
                   });
                   element.css('top', position.top);
                   element.css('left', position.left);
-                  // console.log(element.parent().get(0));
                 }
               };
             }
@@ -124,7 +124,9 @@
         }
 
         if (!scope.isLocal) {
-          $rootScope.$on('tooltip::show', scope.$apply.bind(scope, handleShow));
+          $rootScope.$on('tooltip::show', function (evt, params) {
+            scope.$apply(handleShow.bind(null, evt, params));
+          });
           $rootScope.$on('tooltip::hide', handleHide);
         } else {
           scope.$watch('params', function (newParams) {

--- a/dcc-portal-ui/app/scripts/ui/js/tooltip.js
+++ b/dcc-portal-ui/app/scripts/ui/js/tooltip.js
@@ -29,7 +29,8 @@
       restrict: 'E',
       replace: true,
       scope: {
-        isLocal: '<'
+        isLocal: '<',
+        params: '<',
       },
       templateUrl: 'template/tooltip.html',
       link: function (scope, element) {
@@ -81,14 +82,12 @@
         }
 
         function handleShow(evt, params) {
-          scope.$apply(function() {
-            if (params.text) {
-              scope.html = $sce.trustAsHtml(params.text);
-            }
-            if (params.placement) {
-              scope.placement = params.placement;
-            }
-          });
+          if (params.text) {
+            scope.html = $sce.trustAsHtml(params.text);
+          }
+          if (params.placement) {
+            scope.placement = params.placement;
+          }
 
           element.css('visibility', 'visible');
 
@@ -124,9 +123,20 @@
           element.css('left', -999);
         }
 
-        var scopeToListenOn = scope.isLocal ? scope : $rootScope;
-        scopeToListenOn.$on('tooltip::show', handleShow);
-        scopeToListenOn.$on('tooltip::hide', handleHide);
+        if (!scope.isLocal) {
+          $rootScope.$on('tooltip::show', scope.$apply.bind(scope, handleShow));
+          $rootScope.$on('tooltip::hide', handleHide);
+        } else {
+          scope.$watch('params', function (newParams) {
+            if (!newParams) {
+              return;
+            } else if (newParams.isVisible) {
+              handleShow(null, newParams)
+            } else {
+              handleHide();
+            }
+          });
+        }
       }
     };
   });


### PR DESCRIPTION
Allow "local" `<tooltip-control>`s

Their visibility, position, and content will be passed down via the prop `params`.
The properties of `params` are nearly identical to the event object passed to the app-wide tooltip-control instance, only with an additional `isVisible` boolean field.

Usage example:

``` html
  <tooltip-control
    is-local="true"
    params="vm.tooltipParams"
  ></tooltip-control>
```

``` js
// in the controller, to show the tooltip: 
vm.tooltipParams = {
  isVisible: true, // <-- this is the only thing different
  element: event.target,
  text: tipTemplate({
    donor: _.extend(
      { isCensored: _.includes(ctrl.censoredStatuses,donor.status) },
      donor
    ),
    labels: ctrl.tipLabels,
    unit: 'days'
  }),
  placement: 'right',
  sticky: true
}
```

``` js
// to hide the tooltip
vm.tooltipParams = {
  isVisible: false
};
```
