### PR TITLE
DCC 5021 download unavailable message

### DIFF
--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/AuthenticationExceptionMapper.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/AuthenticationExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 The Ontario Institute for Cancer Research. All rights reserved.                             
+ * Copyright (c) 2016 The Ontario Institute for Cancer Research. All rights reserved.                             
  *                                                                                                               
  * This program and the accompanying materials are made available under the terms of the GNU Public License v3.0.
  * You should have received a copy of the GNU General Public License along with                                  
@@ -33,9 +33,6 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import lombok.NonNull;
-import lombok.val;
-
 import org.icgc.dcc.portal.server.config.ServerProperties.CrowdProperties;
 import org.icgc.dcc.portal.server.model.Error;
 import org.icgc.dcc.portal.server.resource.security.AuthResource;
@@ -44,6 +41,9 @@ import org.icgc.dcc.portal.server.service.AuthenticationException;
 import org.springframework.stereotype.Component;
 
 import com.google.common.collect.Lists;
+
+import lombok.NonNull;
+import lombok.val;
 
 @Component
 @Provider

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/BadRequestExceptionMapper.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/BadRequestExceptionMapper.java
@@ -1,18 +1,19 @@
-/**
- * Copyright 2012(c) The Ontario Institute for Cancer Research. All rights reserved.
- * 
- * This program and the accompanying materials are made available under the terms of the GNU Public
- * License v3.0. You should have received a copy of the GNU General Public License along with this
- * program. If not, see <http://www.gnu.org/licenses/>.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
- * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
- * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/*
+ * Copyright (c) 2016 The Ontario Institute for Cancer Research. All rights reserved.                             
+ *                                                                                                               
+ * This program and the accompanying materials are made available under the terms of the GNU Public License v3.0.
+ * You should have received a copy of the GNU General Public License along with                                  
+ * this program. If not, see <http://www.gnu.org/licenses/>.                                                     
+ *                                                                                                               
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY                           
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES                          
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT                           
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                                
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED                          
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;                               
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER                              
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN                         
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.icgc.dcc.portal.server.jersey.mapper;
 

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/ClientHandlerExceptionMapper.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/ClientHandlerExceptionMapper.java
@@ -19,52 +19,37 @@ package org.icgc.dcc.portal.server.jersey.mapper;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static javax.ws.rs.core.Response.status;
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-
-import java.util.Random;
+import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import org.elasticsearch.ElasticsearchException;
 import org.icgc.dcc.portal.server.model.Error;
 import org.springframework.stereotype.Component;
 
-import lombok.val;
-import lombok.extern.slf4j.Slf4j;
+import com.sun.jersey.api.client.ClientHandlerException;
 
-@Slf4j
+/**
+ * TODO: Remove when https://jira.oicr.on.ca/browse/DCC-5045 is addressed
+ */
 @Component
 @Provider
-public class ElasticSearchExceptionMapper implements ExceptionMapper<ElasticsearchException> {
+public class ClientHandlerExceptionMapper implements ExceptionMapper<ClientHandlerException> {
 
-  private final static Status STATUS = INTERNAL_SERVER_ERROR;
-  private static final Random RANDOM = new Random();
+  private final static Status STATUS = SERVICE_UNAVAILABLE;
 
   @Override
-  public Response toResponse(ElasticsearchException e) {
-
-    val id = RANDOM.nextLong();
-    log.error(formatLogMessage(id), e);
-
+  public Response toResponse(ClientHandlerException e) {
     return status(STATUS)
         .type(APPLICATION_JSON_TYPE)
-        .entity(errorResponse(e, id))
+        .entity(errorResponse(e))
         .build();
   }
 
-  protected String formatLogMessage(long id) {
-    return String.format("Error handling a request: %016x", id);
-  }
-
-  private Error errorResponse(ElasticsearchException e, long id) {
-    return new Error(STATUS, message(e, id));
-  }
-
-  private String message(ElasticsearchException e, long id) {
-    return String.format("%s", formatLogMessage(id));
+  private Error errorResponse(ClientHandlerException e) {
+    return new Error(STATUS, e.getMessage());
   }
 
 }

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/ForbiddenAccessExceptionMapper.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/ForbiddenAccessExceptionMapper.java
@@ -1,18 +1,19 @@
-/**
- * Copyright 2012(c) The Ontario Institute for Cancer Research. All rights reserved.
- * 
- * This program and the accompanying materials are made available under the terms of the GNU Public
- * License v3.0. You should have received a copy of the GNU General Public License along with this
- * program. If not, see <http://www.gnu.org/licenses/>.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
- * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
- * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/*
+ * Copyright (c) 2016 The Ontario Institute for Cancer Research. All rights reserved.                             
+ *                                                                                                               
+ * This program and the accompanying materials are made available under the terms of the GNU Public License v3.0.
+ * You should have received a copy of the GNU General Public License along with                                  
+ * this program. If not, see <http://www.gnu.org/licenses/>.                                                     
+ *                                                                                                               
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY                           
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES                          
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT                           
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                                
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED                          
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;                               
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER                              
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN                         
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.icgc.dcc.portal.server.jersey.mapper;
 

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/GenericExceptionMapper.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/GenericExceptionMapper.java
@@ -1,18 +1,19 @@
-/**
- * Copyright 2012(c) The Ontario Institute for Cancer Research. All rights reserved.
- *
- * This program and the accompanying materials are made available under the terms of the GNU Public
- * License v3.0. You should have received a copy of the GNU General Public License along with this
- * program. If not, see <http://www.gnu.org/licenses/>.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
- * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
- * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/*
+ * Copyright (c) 2016 The Ontario Institute for Cancer Research. All rights reserved.                             
+ *                                                                                                               
+ * This program and the accompanying materials are made available under the terms of the GNU Public License v3.0.
+ * You should have received a copy of the GNU General Public License along with                                  
+ * this program. If not, see <http://www.gnu.org/licenses/>.                                                     
+ *                                                                                                               
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY                           
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES                          
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT                           
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                                
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED                          
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;                               
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER                              
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN                         
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.icgc.dcc.portal.server.jersey.mapper;
 
@@ -49,7 +50,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 @Provider
-@RequiredArgsConstructor(onConstructor = @__(@Autowired) )
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class GenericExceptionMapper implements ExceptionMapper<Throwable> {
 
   private static final Random RANDOM = new Random();

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/IllegalArgumentExceptionMapper.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/IllegalArgumentExceptionMapper.java
@@ -1,18 +1,18 @@
 /*
- * Copyright (c) 2015 The Ontario Institute for Cancer Research. All rights reserved.
- *
+ * Copyright (c) 2016 The Ontario Institute for Cancer Research. All rights reserved.                             
+ *                                                                                                               
  * This program and the accompanying materials are made available under the terms of the GNU Public License v3.0.
- * You should have received a copy of the GNU General Public License along with
- * this program. If not, see <http://www.gnu.org/licenses/>.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
- * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
- * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
- * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
- * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * You should have received a copy of the GNU General Public License along with                                  
+ * this program. If not, see <http://www.gnu.org/licenses/>.                                                     
+ *                                                                                                               
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY                           
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES                          
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT                           
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                                
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED                          
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;                               
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER                              
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN                         
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.icgc.dcc.portal.server.jersey.mapper;

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/NotAvailableExceptionMapper.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/NotAvailableExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 The Ontario Institute for Cancer Research. All rights reserved.                             
+ * Copyright (c) 2016 The Ontario Institute for Cancer Research. All rights reserved.                             
  *                                                                                                               
  * This program and the accompanying materials are made available under the terms of the GNU Public License v3.0.
  * You should have received a copy of the GNU General Public License along with                                  

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/NotFoundExceptionMapper.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/NotFoundExceptionMapper.java
@@ -1,18 +1,19 @@
-/**
- * Copyright 2012(c) The Ontario Institute for Cancer Research. All rights reserved.
- * 
- * This program and the accompanying materials are made available under the terms of the GNU Public
- * License v3.0. You should have received a copy of the GNU General Public License along with this
- * program. If not, see <http://www.gnu.org/licenses/>.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
- * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
- * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/*
+ * Copyright (c) 2016 The Ontario Institute for Cancer Research. All rights reserved.                             
+ *                                                                                                               
+ * This program and the accompanying materials are made available under the terms of the GNU Public License v3.0.
+ * You should have received a copy of the GNU General Public License along with                                  
+ * this program. If not, see <http://www.gnu.org/licenses/>.                                                     
+ *                                                                                                               
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY                           
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES                          
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT                           
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                                
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED                          
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;                               
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER                              
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN                         
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.icgc.dcc.portal.server.jersey.mapper;
 

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/SemanticExceptionMapper.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/SemanticExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 The Ontario Institute for Cancer Research. All rights reserved.                             
+ * Copyright (c) 2016 The Ontario Institute for Cancer Research. All rights reserved.                             
  *                                                                                                               
  * This program and the accompanying materials are made available under the terms of the GNU Public License v3.0.
  * You should have received a copy of the GNU General Public License along with                                  

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/ServiceUnavailableExceptionMapper.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/ServiceUnavailableExceptionMapper.java
@@ -1,18 +1,19 @@
-/**
- * Copyright 2012(c) The Ontario Institute for Cancer Research. All rights reserved.
- * 
- * This program and the accompanying materials are made available under the terms of the GNU Public
- * License v3.0. You should have received a copy of the GNU General Public License along with this
- * program. If not, see <http://www.gnu.org/licenses/>.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
- * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
- * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/*
+ * Copyright (c) 2016 The Ontario Institute for Cancer Research. All rights reserved.                             
+ *                                                                                                               
+ * This program and the accompanying materials are made available under the terms of the GNU Public License v3.0.
+ * You should have received a copy of the GNU General Public License along with                                  
+ * this program. If not, see <http://www.gnu.org/licenses/>.                                                     
+ *                                                                                                               
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY                           
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES                          
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT                           
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                                
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED                          
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;                               
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER                              
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN                         
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.icgc.dcc.portal.server.jersey.mapper;
 

--- a/dcc-portal-ui/app/scripts/advanced/js/advanced.js
+++ b/dcc-portal-ui/app/scripts/advanced/js/advanced.js
@@ -375,7 +375,6 @@ angular.module('icgc.advanced.controllers', [
 
       _controller.downloadDonorData = function() {
         $modal.open({
-          size: 'lg',
           templateUrl: '/scripts/downloader/views/request.html',
           controller: 'DownloadRequestController',
           resolve: {

--- a/dcc-portal-ui/app/scripts/app/js/app.js
+++ b/dcc-portal-ui/app/scripts/app/js/app.js
@@ -614,7 +614,7 @@
         console.error ('Response Error: ', toJson (response));
       }
 
-      if (response.status >= 500) {
+      if (response.status === 500) {
         Notify.setMessage ('' + response.data.message || response.statusText);
         Notify.showErrors();
       } else if (response.status === 404) {

--- a/dcc-portal-ui/app/scripts/downloader/js/request.js
+++ b/dcc-portal-ui/app/scripts/downloader/js/request.js
@@ -30,6 +30,7 @@
     var _isSendingRequest = false;
 
     $scope.params = {};
+    $scope.params.downloadEnabled = true;    
     $scope.params.processing = false;
     $scope.params.dataTypes = [];
 
@@ -134,6 +135,11 @@
         $scope.params.dataTypes = $filter('orderBy')($scope.params.dataTypes, sortFunc);
 
         $scope.params.processing = false;
+      },function (error) {        
+        if(error.status === 503){
+          $scope.params.processing = false;
+          $scope.params.downloadEnabled = false;
+        }         
       });
     };
 

--- a/dcc-portal-ui/app/scripts/downloader/views/request.html
+++ b/dcc-portal-ui/app/scripts/downloader/views/request.html
@@ -14,7 +14,13 @@
       <div data-ng-if="params.processing">
          <i class="icon-spinner icon-spin"></i> Calculating download sizes...
       </div>
-      <div data-ng-if="!params.processing">
+
+      <div class="alert alert-warning" data-ng-if="params.downloadEnabled === false" style="margin:0rem;">
+        Download Donor Data section is currently unavailable due to maintenance.<br>
+        Please contact <a href="mailto:dcc-support@icgc.org">support</a> if you require assistance.
+      </div>
+
+      <div data-ng-if="!params.processing && params.downloadEnabled">
          <span>Search criteria results in <strong>{{totalDonor | number}}</strong> donors. Select data types to download:</span>
          <table class="table table-info">
             <thead>

--- a/dcc-portal-ui/app/scripts/repository/js/repository.js
+++ b/dcc-portal-ui/app/scripts/repository/js/repository.js
@@ -123,6 +123,10 @@
           });
         });
 
+      },function (error) {
+        if(error.status === 503){
+          _ctrl.downloadEnabled = false;
+        }        
       });
     }
 

--- a/dcc-portal-ui/app/scripts/repository/views/repository.icgc.html
+++ b/dcc-portal-ui/app/scripts/repository/views/repository.icgc.html
@@ -14,7 +14,7 @@
     </div>
 
     <section class="alert alert-warning" data-ng-if="ICGCRepoController.downloadEnabled === false">
-    {{:: ICGCRepoController.dataReleasesTitle }} section is currently disabled due to maintenance.<br>
+    {{:: ICGCRepoController.dataReleasesTitle }} section is currently unavailable due to maintenance.<br>
     Please contact <a href="mailto:dcc-support@icgc.org">support</a> if you require assistance.
     </section>
 


### PR DESCRIPTION
Server side code has been updated to throw 503 error whenever the download server is down. Front-End now will catch this error and will show appropriate message to user.

![image](https://cloud.githubusercontent.com/assets/5777761/17178992/8d090250-53e5-11e6-87a1-c031f405602d.png)

![image](https://cloud.githubusercontent.com/assets/5777761/17179100/fa47ccb6-53e5-11e6-91b7-faddbdd49240.png)
