### PR TITLE
Feature/dcc 5097 manifest aggs

### DIFF
--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/model/ManifestSummaryQuery.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/model/ManifestSummaryQuery.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016 The Ontario Institute for Cancer Research. All rights reserved.                             
+ *                                                                                                               
+ * This program and the accompanying materials are made available under the terms of the GNU Public License v3.0.
+ * You should have received a copy of the GNU General Public License along with                                  
+ * this program. If not, see <http://www.gnu.org/licenses/>.                                                     
+ *                                                                                                               
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY                           
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES                          
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT                           
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                                
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED                          
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;                               
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER                              
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN                         
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.icgc.dcc.portal.server.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ManifestSummaryQuery {
+
+  Query query;
+  List<String> repoNames;
+
+}

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/model/UniqueSummaryQuery.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/model/UniqueSummaryQuery.java
@@ -31,7 +31,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ManifestSummaryQuery {
+public class UniqueSummaryQuery {
 
   Query query;
   List<String> repoNames;

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/repository/FileRepository.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/repository/FileRepository.java
@@ -32,6 +32,7 @@ import static org.dcc.portal.pql.query.PqlParser.parse;
 import static org.elasticsearch.action.search.SearchType.COUNT;
 import static org.elasticsearch.action.search.SearchType.QUERY_THEN_FETCH;
 import static org.elasticsearch.action.search.SearchType.SCAN;
+import static org.elasticsearch.index.query.FilterBuilders.boolFilter;
 import static org.elasticsearch.index.query.FilterBuilders.nestedFilter;
 import static org.elasticsearch.index.query.FilterBuilders.termFilter;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
@@ -57,6 +58,7 @@ import static org.icgc.dcc.portal.server.util.JsonUtils.merge;
 import static org.icgc.dcc.portal.server.util.SearchResponses.getHitIds;
 import static org.icgc.dcc.portal.server.util.SearchResponses.getTotalHitCount;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -82,6 +84,7 @@ import org.elasticsearch.index.query.FilterBuilder;
 import org.elasticsearch.index.query.FilteredQueryBuilder;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.nested.Nested;
@@ -92,6 +95,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.TermsBuilder;
 import org.elasticsearch.search.aggregations.metrics.avg.Avg;
 import org.icgc.dcc.portal.server.model.IndexModel.Kind;
 import org.icgc.dcc.portal.server.model.IndexModel.Type;
+import org.icgc.dcc.portal.server.model.ManifestSummaryQuery;
 import org.icgc.dcc.portal.server.model.Query;
 import org.icgc.dcc.portal.server.model.SearchFieldMapper;
 import org.icgc.dcc.portal.server.model.TermFacet;
@@ -428,6 +432,41 @@ public class FileRepository {
     result.add(missingSizeAgg);
 
     return result.build();
+  }
+
+  public SearchResponse getManifestSummary(ManifestSummaryQuery summary) {
+    val pqlAst = PQL_CONVERTER.convert(summary.getQuery(), FILE);
+    val request = queryEngine.execute(pqlAst, FILE).getRequestBuilder();
+
+    val repoNames = summary.getRepoNames();
+    val exclude = new ArrayList<String>();
+
+    val donorAggKey = CustomAggregationKeys.REPO_DONOR_COUNT;
+    val repoSizeAggKey = CustomAggregationKeys.REPO_SIZE;
+
+    val filtersAggs = AggregationBuilders.filters("summary");
+    val repoSizeAgg =
+        nested(repoSizeAggKey).path("file_copies")
+            .subAggregation(sum(repoSizeAggKey).field(toRawFieldName(Fields.FILE_SIZE)));
+
+    for (val repo : repoNames) {
+      val filter = boolFilter().must(nestedFilter("file_copies", termFilter("file_copies.repo_name", repo)));
+      for (val excluded : exclude) {
+        filter.mustNot(nestedFilter("file_copies", termFilter("file_copies.repo_name", excluded)));
+      }
+
+      filtersAggs.filter(repo, filter);
+      exclude.add(repo);
+    }
+
+    filtersAggs
+        .subAggregation(donorIdAgg(donorAggKey))
+        .subAggregation(repoSizeAgg);
+    request.addAggregation(filtersAggs);
+
+    val response = request.execute().actionGet();
+    log.debug("Manifest Summary Response: {}", response);
+    return response;
   }
 
   /**

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/repository/FileRepository.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/repository/FileRepository.java
@@ -94,11 +94,11 @@ import org.elasticsearch.search.aggregations.bucket.terms.TermsBuilder;
 import org.elasticsearch.search.aggregations.metrics.avg.Avg;
 import org.icgc.dcc.portal.server.model.IndexModel.Kind;
 import org.icgc.dcc.portal.server.model.IndexModel.Type;
-import org.icgc.dcc.portal.server.model.UniqueSummaryQuery;
 import org.icgc.dcc.portal.server.model.Query;
 import org.icgc.dcc.portal.server.model.SearchFieldMapper;
 import org.icgc.dcc.portal.server.model.TermFacet;
 import org.icgc.dcc.portal.server.model.TermFacet.Term;
+import org.icgc.dcc.portal.server.model.UniqueSummaryQuery;
 import org.icgc.dcc.portal.server.model.param.FiltersParam;
 import org.icgc.dcc.portal.server.pql.convert.Jql2PqlConverter;
 import org.icgc.dcc.portal.server.service.IndexService;
@@ -448,6 +448,7 @@ public class FileRepository {
     val repoSizeAgg =
         nestedAgg(repoSizeAggKey, EsFields.FILE_COPIES, repoSizeTermsSubAgg);
 
+    // Filters aggregation, where each new filter excludes all the repos that came before it to enforce uniqueness
     for (val repo : repoNames) {
       val filter = boolFilter().must(nestedFilter(EsFields.FILE_COPIES, termFilter("file_copies.repo_name", repo)));
       for (val excluded : exclude) {

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/repository/FileRepository.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/repository/FileRepository.java
@@ -445,9 +445,11 @@ public class FileRepository {
     val repoSizeAggKey = CustomAggregationKeys.REPO_SIZE;
 
     val filtersAggs = AggregationBuilders.filters("summary");
+    val repoSizeTermsSubAgg = terms(repoSizeAggKey).size(MAX_FACET_TERM_COUNT).field(toRawFieldName(Fields.REPO_NAME))
+        .subAggregation(
+            sum(CustomAggregationKeys.FILE_SIZE).field(toRawFieldName(Fields.FILE_SIZE)));
     val repoSizeAgg =
-        nested(repoSizeAggKey).path("file_copies")
-            .subAggregation(sum(repoSizeAggKey).field(toRawFieldName(Fields.FILE_SIZE)));
+        nestedAgg(repoSizeAggKey, EsFields.FILE_COPIES, repoSizeTermsSubAgg);
 
     for (val repo : repoNames) {
       val filter = boolFilter().must(nestedFilter("file_copies", termFilter("file_copies.repo_name", repo)));

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/entity/FileResource.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/entity/FileResource.java
@@ -58,7 +58,7 @@ import javax.ws.rs.core.UriBuilder;
 
 import org.icgc.dcc.portal.server.model.File;
 import org.icgc.dcc.portal.server.model.Files;
-import org.icgc.dcc.portal.server.model.ManifestSummaryQuery;
+import org.icgc.dcc.portal.server.model.UniqueSummaryQuery;
 import org.icgc.dcc.portal.server.model.param.FiltersParam;
 import org.icgc.dcc.portal.server.model.param.IntParam;
 import org.icgc.dcc.portal.server.resource.Resource;
@@ -225,8 +225,8 @@ public class FileResource extends Resource {
   @Timed
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
-  public Map<String, Map<String, Long>> getManifestSummary(ManifestSummaryQuery summary) {
-    return fileService.getManifestSummary(summary);
+  public Map<String, Map<String, Long>> getManifestSummary(UniqueSummaryQuery summary) {
+    return fileService.getUniqueFileAggregations(summary);
   }
 
 }

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/entity/FileResource.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/entity/FileResource.java
@@ -44,6 +44,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -222,6 +223,7 @@ public class FileResource extends Resource {
   @POST
   @Path("/summary/manifest")
   @Timed
+  @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
   public Map<String, Map<String, Long>> getManifestSummary(ManifestSummaryQuery summary) {
     return fileService.getManifestSummary(summary);

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/entity/FileResource.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/entity/FileResource.java
@@ -46,6 +46,7 @@ import java.util.Map;
 
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -56,6 +57,7 @@ import javax.ws.rs.core.UriBuilder;
 
 import org.icgc.dcc.portal.server.model.File;
 import org.icgc.dcc.portal.server.model.Files;
+import org.icgc.dcc.portal.server.model.ManifestSummaryQuery;
 import org.icgc.dcc.portal.server.model.param.FiltersParam;
 import org.icgc.dcc.portal.server.model.param.IntParam;
 import org.icgc.dcc.portal.server.resource.Resource;
@@ -215,6 +217,14 @@ public class FileResource extends Resource {
   @Timed
   public Map<String, String> getIndexMetaData() {
     return fileService.getIndexMetadata();
+  }
+
+  @POST
+  @Path("/summary/manifest")
+  @Timed
+  @Produces(APPLICATION_JSON)
+  public Map<String, Map<String, Long>> getManifestSummary(ManifestSummaryQuery summary) {
+    return fileService.getManifestSummary(summary);
   }
 
 }

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/service/FileService.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/service/FileService.java
@@ -240,7 +240,7 @@ public class FileService {
           long size = getRepoSize((InternalNested) bucket.getAggregations().get("repositorySizes"));
           long donorCount = getDonorCount((InternalNested) bucket.getAggregations().get("repositoryDonors"));
 
-          Map<String, Long> map = ImmutableMap.of("count", count, "size", size, "donorCount", donorCount);
+          Map<String, Long> map = ImmutableMap.of("fileCount", count, "fileSize", size, "donorCount", donorCount);
           return new SimpleImmutableEntry<String, Map<String, Long>>(repo, map);
         }).collect(Collectors.toImmutableMap(e -> e.getKey(), e -> e.getValue()));
 

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/service/FileService.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/service/FileService.java
@@ -29,8 +29,11 @@ import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toMap;
 import static org.elasticsearch.common.collect.Iterables.toArray;
 import static org.icgc.dcc.common.core.util.Joiners.COMMA;
+import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableMap;
 import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableSet;
 import static org.icgc.dcc.portal.server.model.File.parse;
+import static org.icgc.dcc.portal.server.repository.FileRepository.CustomAggregationKeys.REPO_DONOR_COUNT;
+import static org.icgc.dcc.portal.server.repository.FileRepository.CustomAggregationKeys.REPO_SIZE;
 import static org.icgc.dcc.portal.server.util.Collections.isEmpty;
 import static org.icgc.dcc.portal.server.util.SearchResponses.hasHits;
 import static org.supercsv.prefs.CsvPreference.TAB_PREFERENCE;
@@ -43,6 +46,7 @@ import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -60,12 +64,11 @@ import org.elasticsearch.search.aggregations.bucket.nested.InternalNested;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.sum.InternalSum;
-import org.icgc.dcc.common.core.util.stream.Collectors;
 import org.icgc.dcc.portal.server.model.File;
 import org.icgc.dcc.portal.server.model.Files;
 import org.icgc.dcc.portal.server.model.Keyword;
 import org.icgc.dcc.portal.server.model.Keywords;
-import org.icgc.dcc.portal.server.model.ManifestSummaryQuery;
+import org.icgc.dcc.portal.server.model.UniqueSummaryQuery;
 import org.icgc.dcc.portal.server.model.Pagination;
 import org.icgc.dcc.portal.server.model.Query;
 import org.icgc.dcc.portal.server.model.TermFacet;
@@ -229,39 +232,41 @@ public class FileService {
     exportFiles(output, prepResponse, DATA_TABLE_EXPORT_MAP_FIELD_ARRAY);
   }
 
-  public Map<String, Map<String, Long>> getManifestSummary(ManifestSummaryQuery summary) {
+  public Map<String, Map<String, Long>> getUniqueFileAggregations(UniqueSummaryQuery summary) {
     val response = fileRepository.getManifestSummary(summary);
 
     val filtersAggs = (InternalFilters) response.getAggregations().asMap().get("summary");
     val repos = summary.getRepoNames();
     val responseMap = repos.stream()
         .map(repo -> {
+          // Map each repo to an entry keyed off the repo name with the fileCount, fileSize, and donorCount
+          // aggregations in a Map as the value.
           Bucket bucket = filtersAggs.getBucketByKey(repo);
           long count = bucket.getDocCount();
-          long size = getRepoSize((InternalNested) bucket.getAggregations().get("repositorySizes"), repo);
-          long donorCount = getDonorCount((InternalNested) bucket.getAggregations().get("repositoryDonors"));
+          long size = getRepoSize((InternalNested) bucket.getAggregations().get(REPO_SIZE), repo);
+          long donorCount = getDonorCount((InternalNested) bucket.getAggregations().get(REPO_DONOR_COUNT));
 
           Map<String, Long> map = ImmutableMap.of("fileCount", count, "fileSize", size, "donorCount", donorCount);
           return new SimpleImmutableEntry<String, Map<String, Long>>(repo, map);
-        }).collect(Collectors.toImmutableMap(e -> e.getKey(), e -> e.getValue()));
+        }).collect(toImmutableMap(Entry::getKey, Entry::getValue));
 
     return responseMap;
   }
 
   private long getDonorCount(InternalNested aggs) {
-    return ((Terms) aggs.getAggregations().get("repositoryDonors")).getBuckets().size();
+    return ((Terms) aggs.getAggregations().get(REPO_DONOR_COUNT)).getBuckets().size();
   }
 
   private long getRepoSize(InternalNested aggs, String repo) {
-    val stringTerms = (StringTerms) aggs.getAggregations().get("repositorySizes");
-    InternalSum internalSum;
-    try {
-      internalSum = (InternalSum) stringTerms.getBucketByKey(repo).getAggregations().get("fileSize");
-    } catch (NullPointerException e) {
-      // If there are no matching documents for this repo, the bucket will be empty (null).
+    val stringTerms = (StringTerms) aggs.getAggregations().get(REPO_SIZE);
+    val repoBucket = stringTerms.getBucketByKey(repo);
+    // If there are no matching documents for this repo, the bucket will be empty (null).
+    if (repoBucket != null && repoBucket.getAggregations() != null) {
+      val internalSum = (InternalSum) stringTerms.getBucketByKey(repo).getAggregations().get("fileSize");
+      return (long) internalSum.getValue();
+    } else {
       return 0;
     }
-    return (long) internalSum.getValue();
   }
 
   @SneakyThrows

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/service/FileService.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/service/FileService.java
@@ -54,6 +54,7 @@ import org.elasticsearch.common.collect.Iterables;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHitField;
 import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.aggregations.bucket.filters.Filters.Bucket;
 import org.elasticsearch.search.aggregations.bucket.filters.InternalFilters;
 import org.elasticsearch.search.aggregations.bucket.nested.InternalNested;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
@@ -234,12 +235,12 @@ public class FileService {
     val repos = summary.getRepoNames();
     val responseMap = repos.stream()
         .map(repo -> {
-          val bucket = filtersAggs.getBucketByKey(repo);
-          val count = bucket.getDocCount();
-          val size = getRepoSize((InternalNested) bucket.getAggregations().get("repositorySizes"));
-          val donorCount = getDonorCount((InternalNested) bucket.getAggregations().get("repositoryDonors"));
+          Bucket bucket = filtersAggs.getBucketByKey(repo);
+          long count = bucket.getDocCount();
+          long size = getRepoSize((InternalNested) bucket.getAggregations().get("repositorySizes"));
+          long donorCount = getDonorCount((InternalNested) bucket.getAggregations().get("repositoryDonors"));
 
-          val map = ImmutableMap.of("count", count, "size", size, "donorCount", donorCount);
+          Map<String, Long> map = ImmutableMap.of("count", count, "size", size, "donorCount", donorCount);
           return new SimpleImmutableEntry<String, Map<String, Long>>(repo, map);
         }).collect(Collectors.toImmutableMap(e -> e.getKey(), e -> e.getValue()));
 

--- a/dcc-portal-ui/app/scripts/repository/js/repository.js
+++ b/dcc-portal-ui/app/scripts/repository/js/repository.js
@@ -245,6 +245,16 @@
 
       $scope.repos = _.values(repos);
       $scope.selectedRepos = Object.keys(repos);
+
+      var manifestSummaryQuery = {
+        query: p,
+        repoNames: _.map(repos, 'repoName')
+      };
+
+      return ExternalRepoService.getManifestSummary(manifestSummaryQuery).then(
+        function(summary) {
+          $scope.summary = summary;
+        });
     });
 
     $scope.getRepoManifestUrl = ExternalRepoService.getRepoManifestUrl;

--- a/dcc-portal-ui/app/scripts/repository/js/repository.js
+++ b/dcc-portal-ui/app/scripts/repository/js/repository.js
@@ -252,10 +252,22 @@
       };
 
       return ExternalRepoService.getManifestSummary(manifestSummaryQuery).then(
-        function(summary) {
+        function (summary) {
           $scope.summary = summary;
         });
     });
+
+    $scope.movedCallback = function(index) {
+      $scope.repos.splice(index, 1);
+      var manifestSummaryQuery = {
+        query: p,
+        repoNames: _.map($scope.repos, 'repoName')
+      };
+      return ExternalRepoService.getManifestSummary(manifestSummaryQuery).then(
+        function (summary) {
+          $scope.summary = summary;
+        }); 
+    };
 
     $scope.getRepoManifestUrl = ExternalRepoService.getRepoManifestUrl;
 

--- a/dcc-portal-ui/app/scripts/repository/js/services.js
+++ b/dcc-portal-ui/app/scripts/repository/js/services.js
@@ -95,6 +95,11 @@
     };
 
 
+    _srv.getManifestSummary = function(params) {
+      return Restangular.all(REPO_API_PATH + '/summary/manifest')
+        .customPOST(params, undefined, undefined, {'Content-Type': 'application/json'});
+    };
+
     _srv.getList = function (params) {
       var defaults = {
         size: 10,

--- a/dcc-portal-ui/app/scripts/repository/views/repository.external.submit.html
+++ b/dcc-portal-ui/app/scripts/repository/views/repository.external.submit.html
@@ -46,9 +46,9 @@
              <td>
                 {{ repoData.repoName }}
              </td>
-             <td class="text-right">{{ summary[repoData.repoName].donorCount | number }}</td>
-             <td class="text-right">{{ summary[repoData.repoName].fileCount | number }}</td>
-             <td class="text-right">{{ summary[repoData.repoName].fileSize | bytes }}</td>
+             <td class="text-right">{{ summary[repoData.repoName].donorCount || 0 | number }} / {{ repoData.donorCount | number }}</td>
+             <td class="text-right">{{ summary[repoData.repoName].fileCount || 0 | number }} / {{ repoData.fileCount | number }}</td>
+             <td class="text-right">{{ summary[repoData.repoName].fileSize || 0 | bytes }} / {{ repoData.fileSize | bytes }}</td>
              <td class="text-right">
                 <a
                   href="{{getRepoManifestUrl({

--- a/dcc-portal-ui/app/scripts/repository/views/repository.external.submit.html
+++ b/dcc-portal-ui/app/scripts/repository/views/repository.external.submit.html
@@ -46,9 +46,9 @@
              <td>
                 {{ repoData.repoName }}
              </td>
-             <td class="text-right">{{ repoData.donorCount | number }}</td>
-             <td class="text-right">{{ repoData.fileCount | number }}</td>
-             <td class="text-right">{{ repoData.fileSize | bytes }}</td>
+             <td class="text-right">{{ summary[repoData.repoName].donorCount | number }}</td>
+             <td class="text-right">{{ summary[repoData.repoName].fileCount | number }}</td>
+             <td class="text-right">{{ summary[repoData.repoName].fileSize | bytes }}</td>
              <td class="text-right">
                 <a
                   href="{{getRepoManifestUrl({

--- a/dcc-portal-ui/app/scripts/repository/views/repository.external.submit.html
+++ b/dcc-portal-ui/app/scripts/repository/views/repository.external.submit.html
@@ -37,7 +37,7 @@
               data-ng-class="{
                 alt: $index % 2 === 0
               }"
-              dnd-moved="repos.splice($index, 1)"
+              dnd-moved="movedCallback($index)"
               dnd-draggable="repoData"
               dnd-effect-allowed="move"
             >


### PR DESCRIPTION
Opening for testing. 

The manifest model will now show the de-duplicated numbers for donors,files, sizes and it will update based on any drag and drop change of precedence in the repo list. 
