### PR TITLE
Manifest - 2 modes: dedupe and non-dedupe

### DIFF
--- a/dcc-portal-ui/app/scripts/repository/js/repository.js
+++ b/dcc-portal-ui/app/scripts/repository/js/repository.js
@@ -199,6 +199,7 @@
     };
 
     $scope.filters = FilterService.filters;
+    $scope.shouldDedupe = true;
 
     var p = {};
     p.size = 0;

--- a/dcc-portal-ui/app/scripts/repository/styles/_repository.scss
+++ b/dcc-portal-ui/app/scripts/repository/styles/_repository.scss
@@ -86,9 +86,9 @@
       border-left: 0;
       border-right: 0;
       border-bottom: 0;
-      margin-top: 15px;
+      margin-top: 0;
       margin-bottom: 0;
-      th.text-right:last-child {
+      th.text-right:last-child, td.text-right:last-child {
         padding-right: 1em;
       }
       tr {
@@ -136,6 +136,20 @@
       }
       td, th {
         border-left: 0;
+      }
+
+      .handle {
+        width: 2em;
+      }
+      .repo-priority {
+        width: 2em;
+        & + td, & + th {
+          padding-left: 1em;
+        }
+      }
+
+      th:first-child, td:first-child {
+        padding-left: 1em;
       }
 
       .extras {

--- a/dcc-portal-ui/app/scripts/repository/views/repository.external.submit.html
+++ b/dcc-portal-ui/app/scripts/repository/views/repository.external.submit.html
@@ -20,14 +20,28 @@
         </div>
       </div>
 
-       <table class="table table-info">
+      <label class="pull-right">
+        <input
+          type="checkbox"
+          ng-model="shouldDedupe"
+          class="hidden"
+        >
+        <div class="btn btn-xs">
+          <i ng-class="{
+              'icon-check': shouldDedupe,
+              'icon-check-empty': !shouldDedupe
+            }"></i>
+          Deduplicate
+        </div>
+      </label> 
+       <table class="table table-info" ng-class="{'can-reorder': shouldDedupe}">
          <thead>
-           <th class="text-right" colspan="2">Priority</th>
-           <th style="width: 40%;">Repository</th>
+           <th ng-if="shouldDedupe" class="repo-priority text-right" colspan="2">Priority</th>
+           <th class="repo-name" style="width: 40%;">Repository</th>
            <th class="text-right"># Donors</th>
            <th class="text-right"># Files</th>
            <th class="text-right">Total file size</th>
-           <th class="text-right">Manifests</th>
+           <th ng-if="!shouldDedupe" class="text-right">Manifests</th>
          </thead>
 
          <tbody dnd-list="repos">
@@ -40,17 +54,26 @@
               dnd-draggable="repoData"
               dnd-dragstart="closeDropdowns()"
               dnd-effect-allowed="move"
+              dnd-disable-if="!shouldDedupe"
             >
-             <td class="handle text-right ">&nbsp;::: </td>
-             <td class="text-right">{{$index + 1}}.</td>
-             <td>
+             <td ng-if="shouldDedupe" class="handle text-right ">&nbsp;::: </td>
+             <td ng-if="shouldDedupe" class="repo-priority text-right">{{$index + 1}}.</td>
+
+             <td class="repo-name">
                 <i ng-if="repoData.isCloud" class="icon-cloud"></i>
                 {{ repoData.repoName }}
              </td>
-             <td class="text-right">{{ summary[repoData.repoName].donorCount || 0 | number }} / {{ repoData.donorCount | number }}</td>
-             <td class="text-right">{{ summary[repoData.repoName].fileCount || 0 | number }} / {{ repoData.fileCount | number }}</td>
-             <td class="text-right">{{ summary[repoData.repoName].fileSize || 0 | bytes }} / {{ repoData.fileSize | bytes }}</td>
-             <td class="text-right">
+
+             <td ng-if="shouldDedupe" class="text-right">{{ summary[repoData.repoName].donorCount || 0 | number }}</td>
+             <td ng-if="!shouldDedupe" class="text-right">{{ repoData.donorCount | number }}</td>
+
+             <td ng-if="shouldDedupe" class="text-right">{{ summary[repoData.repoName].fileCount || 0 | number }}</td>
+             <td ng-if="!shouldDedupe" class="text-right">{{ repoData.fileCount | number }}</td>
+
+             <td ng-if="shouldDedupe" class="text-right">{{ summary[repoData.repoName].fileSize || 0 | bytes }}</td>
+             <td ng-if="!shouldDedupe" class="text-right">{{ repoData.fileSize | bytes }}</td>
+
+             <td ng-if="!shouldDedupe" class="text-right">
                 <a
                   href="{{getRepoManifestUrl({
                     repoCodes: [repoData.repoCode],
@@ -109,7 +132,7 @@
               repoData.manifestID ||
               repoData.shortUrl"
             >
-              <td colspan="7" class="text-right">
+              <td colspan="5" class="text-right">
                 <div class="spinner-container" data-ng-if="repoData.isGeneratingManifestShortUrl || repoData.isGeneratingManifestID">
                   <i class="icon-spinner icon-spin"></i>
                 </div>
@@ -213,6 +236,6 @@
 
     <div class="modal-footer">
       <button class="t_button" data-ng-click="cancel();">Cancel</button>
-      <button class="t_button" data-ng-click="download()"><i class="icon-download"></i>Download All</button>
+      <button ng-disabled="!shouldDedupe" class="t_button" data-ng-click="shouldDedupe && download()"><i class="icon-download"></i>Download All</button>
     </div>
 </div>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/743976/17488643/450ff238-5d68-11e6-9358-80561c69f238.png)
![image](https://cloud.githubusercontent.com/assets/743976/17488647/4a2b92ea-5d68-11e6-995d-7d91425fb9f6.png)

IMO it's not obvious to users why  
- "Download all" is disabled when not deduplicating
- Individual downloads are disabled when deduplicating

Also don't like that there is no obvious visual indications to differentiate when the table is drag-and-drop-able vs not-drag-and-drop-able (yes the handle ::: went away, but since it wasn't necessary to drag _on_ the :::, the existence of ::: merely served to cue in the user that the rows were drag&drop-able)
