### PR TITLE
DCC-5156 Text wrap on summary section GENES entity page

### DIFF
--- a/dcc-portal-ui/app/styles/_modules/_hide.scss
+++ b/dcc-portal-ui/app/styles/_modules/_hide.scss
@@ -17,6 +17,7 @@
 
 .t_sh {
   @include clearfix();
+  word-break: break-word;
 }
 
 .t_sh__hidden {

--- a/dcc-portal-ui/app/styles/_modules/_hide.scss
+++ b/dcc-portal-ui/app/styles/_modules/_hide.scss
@@ -17,7 +17,9 @@
 
 .t_sh {
   @include clearfix();
-  word-break: break-word;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  word-break: normal;
 }
 
 .t_sh__hidden {


### PR DESCRIPTION
CSS added to break the words for proper text wrap.
