### PR TITLE
DCC 5151 stacked bar click issue

### DIFF
--- a/dcc-portal-ui/app/scripts/stackedbarchart/js/stackedbar.js
+++ b/dcc-portal-ui/app/scripts/stackedbarchart/js/stackedbar.js
@@ -168,21 +168,28 @@
         .attr ('y', function (d) {return y (d.y0);})
         .attr ('height', 0)
         .on('mouseover', function(d) {
+          var rect = d3.select(this);
 
-          svg.append('rect')
-            .classed('chart-focus', true)
-            .attr('x', x(d.key))
-            .attr('y', y(d.y1))
-            .attr('width', x.rangeBand())
-            .attr('height', function() { return y(d.y0) - y(d.y1); })
-            .attr('fill', 'none')
-            .attr('stroke', '#283e5d')
+          bar.selectAll('.stack')
+            .transition()
+            .attr({opacity: 0.5});
+
+          rect.transition()
+            .attr({opacity: 1});
+
+          rect.attr('stroke', '#283e5d')
             .attr('stroke-width', 2);
 
           config.tooltipShowFunc(this,d);
         })
         .on('mouseout', function() {
-          svg.selectAll('.chart-focus').remove();
+          var rect = d3.select(this);
+
+          bar.selectAll('.stack')
+            .transition()
+            .attr({opacity: 1});
+
+          rect.attr('stroke', 'none');
 
           config.tooltipHideFunc();
         })


### PR DESCRIPTION
Instead of creating a new element on mouseover, the affected svg element is now updated to show the stroke. This way the click event attached to it doesn't get overwritten. Added transition animation to change opacity of the bar based mouseover event.
