### PR TITLE
DCC 5172 Donor Treatment Type missing when populated

### DIFF
--- a/dcc-portal-ui/app/scripts/donors/views/donor.specimen.html
+++ b/dcc-portal-ui/app/scripts/donors/views/donor.specimen.html
@@ -39,11 +39,11 @@
                 </tr>
                 <tr>
                     <th><translate>Donor Treatment Type</translate></th>
-                    <td>{{ DonorSpecimenCtrl.specimen.donorTreatmentType }}</td>
+                    <td>{{ DonorSpecimenCtrl.specimen.treatmentType }}</td>
                 </tr>
                 <tr>
                     <th><translate>Donor Treatment Type Other</translate></th>
-                    <td>{{ DonorSpecimenCtrl.specimen.donorTreatmentTypeOther }}</td>
+                    <td>{{ DonorSpecimenCtrl.specimen.treatmentTypeOther }}</td>
                 </tr>
                 <tr>
                     <th><translate>Specimen Processing</translate></th>


### PR DESCRIPTION
Wrong JSON key was being used. Updated the key value in front end.
