### PR TITLE
DCC 5176 Update search labels to remove '_' from strings

### DIFF
--- a/dcc-portal-ui/app/scripts/common/js/translator.js
+++ b/dcc-portal-ui/app/scripts/common/js/translator.js
@@ -38,7 +38,7 @@
      function humanReadable(str) {
        var res = str;
        if (_.isEmpty(res) === true) { return res; }
-       res = res.replace(/_/g, ' ').replace(/^\s+|\s+$/g, '');
+       res = res.replace(/_/g, '\u00A0').replace(/^\s+|\s+$/g, '');
        res = res.charAt(0).toUpperCase() + res.slice(1);
        return res;
      }

--- a/dcc-portal-ui/app/scripts/keyword/views/results.html
+++ b/dcc-portal-ui/app/scripts/keyword/views/results.html
@@ -53,7 +53,7 @@
             <tr data-ng-repeat="r in results.hits" data-ng-switch="r.type" class="t_quick__hit type-{{r.type}}">
                 <td class="t_quick__hit__type">
                     <span class="{{ badgeStyleClass (r.type) }}" />
-                    <div class="t_badge__label">{{r.type}}</div>
+                    <div class="t_badge__label">{{r.type | trans}}</div>
                 </td>
 
                 <td class="t_quick__hit__text" data-ng-switch-when="compound">

--- a/dcc-portal-ui/app/scripts/ui/views/suggest_popup.html
+++ b/dcc-portal-ui/app/scripts/ui/views/suggest_popup.html
@@ -10,7 +10,7 @@
             class="t_suggest_flyout__hits__hit type-{{r.type}}">
             <td class="t_suggest_flyout__hits__hit__type">
                 <span class="{{ badgeStyleClass (r.type) }}"></span>
-                <span class="t_badge__label">{{r.type}}</span>
+                <span class="t_badge__label">{{r.type | trans}}</span>
             </td>
             <td class="t_suggest_flyout__hits__hit__text">
                 <span>


### PR DESCRIPTION
Search result type now goes through the `trans` filter. Added unicod for space in 'trans' filter function so that the string doest break into new line.
