### PR TITLE
Fixes return of mutation counts for drugs

### DIFF
--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/entity/DrugResource.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/entity/DrugResource.java
@@ -46,9 +46,9 @@ import static org.icgc.dcc.portal.server.resource.Resources.MULTIPLE_IDS;
 import static org.icgc.dcc.portal.server.resource.Resources.RETURNS_LIST;
 import static org.icgc.dcc.portal.server.resource.Resources.S;
 
-import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -112,7 +112,7 @@ public class DrugResource extends Resource {
   @GET
   @Timed
   @ApiOperation(value = "Find most frequently mutated genes targeted by a drug", response = List.class)
-  public List<SimpleImmutableEntry<String, Long>> topMutatedGenes(
+  public List<Map<String, Object>> topMutatedGenes(
       @ApiParam(value = "Drug ID", required = true) @PathParam("drugId") String drugId,
       @ApiParam(value = API_FILTER_VALUE) @QueryParam(API_FILTER_PARAM) @DefaultValue(DEFAULT_FILTERS) FiltersParam filtersParam,
       @ApiParam(value = API_SIZE_VALUE, allowableValues = API_SIZE_ALLOW) @QueryParam(API_SIZE_PARAM) @DefaultValue(DEFAULT_SIZE) IntParam size,

--- a/dcc-portal-ui/app/scripts/compounds/js/compounds.js
+++ b/dcc-portal-ui/app/scripts/compounds/js/compounds.js
@@ -407,11 +407,11 @@ angular.module('icgc.compounds.services', ['icgc.genes.models'])
 
             for (var i = 0; i < geneCount; i++) {
               var mutationData = mutationCountData[i],
-                geneId = _.get(mutationData, 'key', false);
+                geneId = _.get(mutationData, 'geneId', false);
 
               if (geneId) {
                 _compoundTargetedGeneIds.push(geneId);
-                mutationGeneValueMap[geneId] = +mutationData.value;
+                mutationGeneValueMap[geneId] = +mutationData.mutationCount;
               }
             }
 


### PR DESCRIPTION
Updates mapping of Gene and Mutation count after an update to jackson
made it so ImmutableEntries are mapped without the key and value
keywords.
