### PR TITLE
Feature/dcc 5195 onco project page

### DIFF
--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/analysis/OncogridAnalysisResource.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/analysis/OncogridAnalysisResource.java
@@ -15,33 +15,27 @@
  * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN                         
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.icgc.dcc.portal.server.resource;
-
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-
-import java.util.UUID;
-
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-
-import org.icgc.dcc.portal.server.model.OncogridAnalysis;
-import org.icgc.dcc.portal.server.model.OncogridAnalysisRequest;
-import org.icgc.dcc.portal.server.service.OncogridAnalysisService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+package org.icgc.dcc.portal.server.resource.analysis;
 
 import io.swagger.annotations.ApiParam;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.icgc.dcc.portal.server.model.OncogridAnalysis;
+import org.icgc.dcc.portal.server.model.OncogridAnalysisRequest;
+import org.icgc.dcc.portal.server.resource.Resource;
+import org.icgc.dcc.portal.server.service.OncogridAnalysisService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.ws.rs.*;
+import java.util.UUID;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Component
 @Path("/v1/analysis/oncogrid")
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
-public class OncogridAnalaysisResource extends Resource {
+public class OncogridAnalysisResource extends Resource {
 
   @NonNull
   private final OncogridAnalysisService service;

--- a/dcc-portal-ui/app/scripts/analysis/js/analysisLauncher.js
+++ b/dcc-portal-ui/app/scripts/analysis/js/analysisLauncher.js
@@ -86,7 +86,7 @@
     };
 
     _this.validForOnco = function(set) {
-      return set.count <= 100;
+      return (set.type === 'gene' && set.count <= 100) || (set.type === 'donor' && set.count <= 3000);
     };
 
     _this.applyFilter = function(type) {

--- a/dcc-portal-ui/app/scripts/analysis/views/analysis.analysis.launcher.html
+++ b/dcc-portal-ui/app/scripts/analysis/views/analysis.analysis.launcher.html
@@ -294,7 +294,7 @@
 
         <!-- OncoGrid -->
         <div data-ng-if="NAC.analysisType === 'oncogrid'">
-            <div><translate has-markup><em>Select 1 Gene set <small>(100 genes maximum)</small> and 1 Donor set <small>(100 donors maximum)</small>, then click on Run.</em></translate></div>
+            <div><translate has-markup><em>Select 1 Gene set <small>(100 genes maximum)</small> and 1 Donor set <small>(3000 donors maximum)</small>, then click on Run.</em></translate></div>
             <div><translate>Demo</translate>: <a href="" data-ng-click="NAC.demoOncogrid()">{{NAC.analysisDemoDescription('oncogrid')}}</a></div>
             
             <div> 

--- a/dcc-portal-ui/app/scripts/oncogrid/views/oncogrid-analysis.html
+++ b/dcc-portal-ui/app/scripts/oncogrid/views/oncogrid-analysis.html
@@ -26,7 +26,7 @@
           <tr>
             <td><translate>Donor</translate></td>
             <td>{{item.donorSetName}}</td>
-            <td class="text-right"><a href="{{donorLink}}">{{item.donorCount}}</a></td>
+            <td class="text-right"><a href="{{donorLink}}">{{item.donorCount | number}}</a></td>
             <td style="font-size:1.25rem;">                            
               <span class="t_tools__tool">
                 <i class="icon-file" data-tooltip="{{'Export as TSV' | translate}}" data-ng-click="exportSet(item.donorSet)"></i>
@@ -46,7 +46,7 @@
           <tr>
             <td><translate>Gene</translate></td>
             <td>{{item.geneSetName}}</td>
-            <td class="text-right"><a href="{{geneLink}}">{{item.geneCount}}</a></td>
+            <td class="text-right"><a href="{{geneLink}}">{{item.geneCount | number}}</a></td>
             <td style="font-size:1.25rem;">                            
               <span class="t_tools__tool">
                 <i class="icon-file" data-tooltip="{{'Export as TSV' | translate}}" data-ng-click="exportSet(item.geneSet)"></i>

--- a/dcc-portal-ui/app/scripts/projects/js/projects.js
+++ b/dcc-portal-ui/app/scripts/projects/js/projects.js
@@ -489,7 +489,7 @@
 
       var donorParams = {
         filters: filter,
-        size: 75,
+        size: 2000,
         isTransient: true,
         name: project.id + ': Top 75 Donors w/ High Impact',
         sortBy: 'ssmAffectedGenes',
@@ -498,7 +498,7 @@
 
       var geneParams = {
         filters: filter,
-        size: 75,
+        size: 50,
         isTransient: true,
         name: project.id + ': Top 75 Genes w/ High Impact',
         sortBy: 'affectedDonorCountFiltered',

--- a/dcc-portal-ui/app/scripts/projects/js/projects.js
+++ b/dcc-portal-ui/app/scripts/projects/js/projects.js
@@ -491,7 +491,7 @@
         filters: filter,
         size: 2000,
         isTransient: true,
-        name: project.id + ': Top 75 Donors w/ High Impact',
+        name: project.id + ': All donors',
         sortBy: 'ssmAffectedGenes',
         sortOrder: 'DESCENDING',
       };
@@ -500,7 +500,7 @@
         filters: filter,
         size: 50,
         isTransient: true,
-        name: project.id + ': Top 75 Genes w/ High Impact',
+        name: project.id + ': Top 50 genes w/ high impact',
         sortBy: 'affectedDonorCountFiltered',
         sortOrder: 'DESCENDING',
       };

--- a/dcc-portal-ui/app/scripts/projects/js/projects.js
+++ b/dcc-portal-ui/app/scripts/projects/js/projects.js
@@ -495,7 +495,7 @@
         filters: filter,
         size: 50,
         isTransient: true,
-        name: 'Top 50 ' + project.id + 'Mutated Genes',
+        name: 'Top 50 ' + project.id + ' Mutated Genes',
         sortBy: 'affectedDonorCountFiltered',
         sortOrder: 'DESCENDING',
       };

--- a/dcc-portal-ui/app/scripts/projects/js/projects.js
+++ b/dcc-portal-ui/app/scripts/projects/js/projects.js
@@ -479,19 +479,14 @@
           projectId: {
             is: [project.id]
           }
-        },
-        mutation: {
-          functionalImpact: {
-            is: ['High']
-          }
         }
       };
 
       var donorParams = {
         filters: filter,
-        size: 2000,
+        size: 3000,
         isTransient: true,
-        name: project.id + ': All donors',
+        name: project.id +  ' Donors',
         sortBy: 'ssmAffectedGenes',
         sortOrder: 'DESCENDING',
       };
@@ -500,7 +495,7 @@
         filters: filter,
         size: 50,
         isTransient: true,
-        name: project.id + ': Top 50 genes w/ high impact',
+        name: 'Top 50 ' + project.id + 'Mutated Genes',
         sortBy: 'affectedDonorCountFiltered',
         sortOrder: 'DESCENDING',
       };

--- a/dcc-portal-ui/app/scripts/projects/views/project.html
+++ b/dcc-portal-ui/app/scripts/projects/views/project.html
@@ -318,7 +318,7 @@
     <div>
         <span class="open-in"><translate>Open in</translate></span>
         <a href="#" data-ng-click="ProjectCtrl.openOncogrid()">
-            <i class="icon-grid"></i>OncoGrid with top 75 High Impact Donor and Genes
+            <i class="icon-grid"></i>OncoGrid with top 50 High Impact Genes
         </a>
     </div>
 </div>

--- a/dcc-portal-ui/app/scripts/projects/views/project.html
+++ b/dcc-portal-ui/app/scripts/projects/views/project.html
@@ -336,7 +336,7 @@
             <br>
             <span class="pull-right open-in">
                 <a href="#" data-ng-click="ProjectCtrl.openOncogrid()">
-                    <i class="icon-grid"></i><translate>OncoGrid with top 50 High Impact Genes</translate>
+                    <i class="icon-grid"></i><translate>OncoGrid</translate>
                 </a>
             </span>
         </h3>

--- a/dcc-portal-ui/app/scripts/projects/views/project.html
+++ b/dcc-portal-ui/app/scripts/projects/views/project.html
@@ -309,10 +309,18 @@
             </td>
         </tr>
     </table>
-    <span class="open-in"><translate>Open in</translate></span>
-    <a href="{{:: ProjectCtrl.dataReleasesUrl }}/current/Projects/{{ProjectCtrl.project.id}}">
-      <i class="icon-database"></i>{{:: ProjectCtrl.dataReleasesTitle }}
-    </a>
+    <div>
+        <span class="open-in"><translate>Open in</translate></span>
+        <a href="{{:: ProjectCtrl.dataReleasesUrl }}/current/Projects/{{ProjectCtrl.project.id}}">
+        <i class="icon-database"></i>{{:: ProjectCtrl.dataReleasesTitle }}
+        </a>
+    </div>
+    <div>
+        <span class="open-in"><translate>Open in</translate></span>
+        <a href="#" data-ng-click="ProjectCtrl.openOncogrid()">
+            <i class="icon-grid"></i>OncoGrid with top 75 High Impact Donor and Genes
+        </a>
+    </div>
 </div>
 </section>
 <section id="genes"

--- a/dcc-portal-ui/app/scripts/projects/views/project.html
+++ b/dcc-portal-ui/app/scripts/projects/views/project.html
@@ -315,12 +315,6 @@
         <i class="icon-database"></i>{{:: ProjectCtrl.dataReleasesTitle }}
         </a>
     </div>
-    <div>
-        <span class="open-in"><translate>Open in</translate></span>
-        <a href="#" data-ng-click="ProjectCtrl.openOncogrid()">
-            <i class="icon-grid"></i>OncoGrid with top 50 High Impact Genes
-        </a>
-    </div>
 </div>
 </section>
 <section id="genes"
@@ -339,6 +333,12 @@
         <h3>
             <translate>Most Frequently Mutated Genes</translate>
             <span data-open-in-list='/g?filters={{ProjectGeneCtrl.genes.advQuery}}'></span>
+            <br>
+            <span class="pull-right open-in">
+                <a href="#" data-ng-click="ProjectCtrl.openOncogrid()">
+                    <i class="icon-grid"></i><translate>OncoGrid with top 50 High Impact Genes</translate>
+                </a>
+            </span>
         </h3>
 
         <div class="clearfix">
@@ -353,7 +353,8 @@
                 Showing <strong>{{ProjectGeneCtrl.genes.hits.length | number}}</strong> of
                 <strong>{{ProjectGeneCtrl.genes.pagination.total | number}}</strong> genes
             </translate>
-            <span data-toolbar data-dl="{{ProjectCtrl.project.id}}_genes"></span>
+            <span data-toolbar data-dl="{{ProjectCtrl.project.id}}_genes">
+            </span>
         </div>
         <table class="table table-bordered table-striped table-condensed">
             <thead>

--- a/dcc-portal-ui/app/scripts/sets/js/services.js
+++ b/dcc-portal-ui/app/scripts/sets/js/services.js
@@ -156,7 +156,7 @@
       var filters = {};
     	var type = 'file';
       filters[type] = {};
-      filters[type][Extensions.ENTITY] = {is: [set.id]};
+      filters[type] = {donorId: {is: [Extensions.ENTITY_PREFIX + set.id]}};
 
       return dataRepoUrl + '?filters=' + angular.toJson(filters);
     };

--- a/dcc-portal-ui/app/scripts/ui/views/open_in.html
+++ b/dcc-portal-ui/app/scripts/ui/views/open_in.html
@@ -3,9 +3,9 @@
     <a data-ng-if="type !== 'viewer'" href="/search{{openInList}}"><translate>Advanced Search</translate></a>
     <span data-ng-if="['donor','viewer'].indexOf(type) === -1">|</span>
     <a data-ng-if="type !== 'donor' && context===null" href="/browser{{openInList}}">
-        <translate>Genome Viewer</translate>
+        <i class="icon-chart"></i><translate>Genome Viewer</translate>
     </a>
     <a data-ng-if="type !== 'donor' && context==='donor'" href="/browser{{openInViewer}}&context={{context}}">
-        <translate>Genome Viewer</translate>
+        <i class="icon-chart"></i><translate>Genome Viewer</translate>
     </a>
 </span>

--- a/dcc-portal-ui/app/vendor/scripts/oncogrid/oncogrid-debug.js
+++ b/dcc-portal-ui/app/vendor/scripts/oncogrid/oncogrid-debug.js
@@ -117,7 +117,7 @@ OncoHistogram.prototype.render = function (x, div) {
         .attr('class', function (d) {
             return _self.prefix + 'sortable-bar ' + d.id + '-bar';
         })
-        .attr('width', _self.barWidth - 1)
+        .attr('width', _self.barWidth - (_self.barWidth < 3 ? 0 : 1)) // If bars are small, do not use whitespace.
         .attr('height', function (d) {
             return _self.histogramHeight * d.count / topCount;
         })
@@ -138,7 +138,7 @@ OncoHistogram.prototype.update = function (domain, x) {
 
     _self.histogram.selectAll('rect')
         .transition()
-        .attr('width', _self.barWidth - 1)
+        .attr('width', _self.barWidth - (_self.barWidth < 3 ? 0 : 1)) // If bars are small, do not use whitespace.
         .attr('x', function (d) {
             return _self.x(_self.getIndex(_self.domain, d.id));
         });


### PR DESCRIPTION
Possible to go from Project entity page to OncoGrid, viewing all donors in project and top 50 genes for the project with High Impact mutations. 

<img width="1049" alt="screen shot 2016-09-09 at 11 11 56 am" src="https://cloud.githubusercontent.com/assets/6350043/18392043/47b90f40-767e-11e6-87d5-c32eeff9d724.png">

Updated oncogrid to eliminate the whitespace between histogram bars, when the width of the bars decreases beyond a threshold. 

<img width="956" alt="screen shot 2016-09-09 at 11 12 12 am" src="https://cloud.githubusercontent.com/assets/6350043/18392044/48dcd492-767e-11e6-9820-7e5a907097de.png">
