### PR TITLE
DCC-5185 Incorrect threshold shown on the Save File Set under Data Repositories

### DIFF
--- a/dcc-portal-ui/app/scripts/sets/views/sets.upload.external.html
+++ b/dcc-portal-ui/app/scripts/sets/views/sets.upload.external.html
@@ -17,7 +17,7 @@
                 data-ng-model="params.setSize" data-ng-change="validateInput()">
             <br>
             <small>
-                <translate>You can save up to the top {{params.setLimit | number}} {{params.setType}}s</translate>
+                <translate>You can save up to the top {{params.setSizeLimit | number}} {{params.setType}}s</translate>
             </small>
         </div>
 


### PR DESCRIPTION
Changed text to reflect limit of files can be saved
