### PR TITLE
DCC-5205: Bug fix for icgcget generating incorrect manifests

### DIFF
--- a/dcc-portal-ui/app/scripts/repository/js/repository.js
+++ b/dcc-portal-ui/app/scripts/repository/js/repository.js
@@ -202,9 +202,11 @@
 
     var filters = _.extend({},
       FilterService.filters(),
-      _.isEmpty(params.selectedFiles) ? {
+      !_.isEmpty(params.selectedFiles) ? {
         file: {
-          id: params.selectedFiles
+          id: {
+            is: params.selectedFiles
+          }
         }
       } : {}
     );

--- a/dcc-portal-ui/app/scripts/repository/views/repository.external.icgc-get.html
+++ b/dcc-portal-ui/app/scripts/repository/views/repository.external.icgc-get.html
@@ -49,7 +49,7 @@ repositories.
         Usage example:
       </span>
       <code class="inline-code" ng-class="{ 'text-center': vm.loadState.isLoading }">
-        <span ng-if="vm.manifestId">./icgc-get download {{vm.manifestId}}</span>
+        <span ng-if="vm.manifestId">./icgc-get download -m {{vm.manifestId}}</span>
         <i
           class="icon-spin icon-spinner"
           ng-class="{ 'hidden': !vm.loadState.isLoading }"


### PR DESCRIPTION
@btiernay This is urgent and related to DCC-5205.

The generated command is wrong as it is missing the `-m` option. 

The filter was being broken in the UI when POSTing to manifest resource so no matter what, your manifest ID would contain the entire repository index. This also caused the icgc-get client to fail. 
