### PR TITLE
Remove manual DI annotations (Fixes DCC-5244)

### DIFF
--- a/dcc-portal-ui/app/scripts/app/js/app.js
+++ b/dcc-portal-ui/app/scripts/app/js/app.js
@@ -579,10 +579,10 @@
       'team', {
         url: '/team',
         templateUrl: '/scripts/static/views/team.html',
-        controller: ['Page', function (Page, gettextCatalog) {
+        controller: function (Page, gettextCatalog) {
           Page.setTitle(gettextCatalog.getString('The Team'));
           Page.setPage('entity');
-        }]
+        }
       });
 
     // All else redirect to home


### PR DESCRIPTION
`gettextCatalog` was missing from manual DI annotation and thus was undefined

removed manual DI annotation and letting ng-annotate build step handle it
