### PR TITLE
DCC 5246 README 404 error

### DIFF
--- a/dcc-portal-ui/app/scripts/repository/js/repository.js
+++ b/dcc-portal-ui/app/scripts/repository/js/repository.js
@@ -126,15 +126,17 @@
 
             // Workaround for links in README file on Releases page
 
-            angular.element('.markdown_wrapper').delegate('a', 'click', function(){
+            angular.element('.markdown-container').delegate('a', 'click', function(){
               var _elem = jQuery(this),
                 _href = _elem.attr('href');
               
               if(_href.indexOf('@') !== -1){
-                _elem.attr('href', 'mailto:' + _href);
+                window.location.href = 'mailto:' + _href;
+                return false;
               }
               else if(_href.indexOf('http') === -1) {
-                _elem.attr('href', 'http://' + _href);
+                window.location.href = 'http://' + _href;
+                return false;
               }
             });
           });

--- a/dcc-portal-ui/app/scripts/repository/js/repository.js
+++ b/dcc-portal-ui/app/scripts/repository/js/repository.js
@@ -123,6 +123,9 @@
           Restangular.one('download').get( {'fn':f.name}).then(function(data) {
             f.textContent = data;
           }).then(function(){
+
+            // Workaround for links in README file on Releases page
+
             angular.element('.markdown_wrapper').delegate('a', 'click', function(){
               var _elem = jQuery(this),
                 _href = _elem.attr('href');

--- a/dcc-portal-ui/app/scripts/repository/js/repository.js
+++ b/dcc-portal-ui/app/scripts/repository/js/repository.js
@@ -130,7 +130,7 @@
               if(_href.indexOf('@') !== -1){
                 _elem.attr('href', 'mailto:' + _href);
               }
-              else if(_href.indexOf('http') == -1) {
+              else if(_href.indexOf('http') === -1) {
                 _elem.attr('href', 'http://' + _href);
               }
             });

--- a/dcc-portal-ui/app/scripts/repository/js/repository.js
+++ b/dcc-portal-ui/app/scripts/repository/js/repository.js
@@ -122,6 +122,18 @@
         _ctrl.textFiles.forEach(function(f) {
           Restangular.one('download').get( {'fn':f.name}).then(function(data) {
             f.textContent = data;
+          }).then(function(){
+            angular.element('.markdown_wrapper').delegate('a', 'click', function(){
+              var _elem = jQuery(this),
+                _href = _elem.attr('href');
+              
+              if(_href.indexOf('@') !== -1){
+                _elem.attr('href', 'mailto:' + _href);
+              }
+              else if(_href.indexOf('http') == -1) {
+                _elem.attr('href', 'http://' + _href);
+              }
+            });
           });
         });
 

--- a/dcc-portal-ui/app/scripts/repository/views/repository.icgc.html
+++ b/dcc-portal-ui/app/scripts/repository/views/repository.icgc.html
@@ -76,8 +76,8 @@
                <div class="well well-small">
                    <div><a target="_self" href="{{ICGCRepoController.API.BASE_URL}}/download?fn={{file.name}}"><i class="icon-file"></i>{{file.baseName}}</a></div>
                    <hr>
-                   <div class="markdown_container">
-                       <div btf-markdown="file.textContent"></div>
+                   <div class="markdown_container" >
+                       <div btf-markdown="file.textContent" class="markdown_wrapper"></div>
                    </div>
                </div>
            </div>

--- a/dcc-portal-ui/app/scripts/repository/views/repository.icgc.html
+++ b/dcc-portal-ui/app/scripts/repository/views/repository.icgc.html
@@ -76,8 +76,8 @@
                <div class="well well-small">
                    <div><a target="_self" href="{{ICGCRepoController.API.BASE_URL}}/download?fn={{file.name}}"><i class="icon-file"></i>{{file.baseName}}</a></div>
                    <hr>
-                   <div class="markdown_container" >
-                       <div btf-markdown="file.textContent" class="markdown_wrapper"></div>
+                   <div class="markdown-wrapper" >
+                       <div btf-markdown="file.textContent" class="markdown-container"></div>
                    </div>
                </div>
            </div>

--- a/dcc-portal-ui/app/styles/override.css
+++ b/dcc-portal-ui/app/styles/override.css
@@ -91,35 +91,35 @@ textarea {
    color: rgb(220, 50, 47) !important;
 }
 
-.markdown_container td,
-.markdown_container th {
+.markdown-wrapper td,
+.markdown-wrapper th {
    border: 1px solid rgb(230, 230, 230);
    text-align: left;
    padding: .2rem .4rem;
    line-height: 1rem;
 }
 
-.markdown_container p,
+.markdown-wrapper p,
 .release_notice p{
    margin-top: 0.5rem;
    margin-bottom: 1.0rem;
 }
 
-.markdown_container h1,
+.markdown-wrapper h1,
 .release_notice h1 {
    margin-top: 0.5rem;
    margin-bottom: 0.5rem;
    font-size: 2rem;
 }
 
-.markdown_container h2,
+.markdown-wrapper h2,
 .release_notice h2 {
    margin-top: 0.5rem;
    margin-bottom: 0.5rem;
    font-size: 1.75rem;
 }
 
-.markdown_container h3,
+.markdown-wrapper h3,
 .release_notice h3 {
    margin-top: 0.5rem;
    margin-bottom: 0.5rem;


### PR DESCRIPTION
Checking if the links has proper prepended attributes. 
- Email links should have `mailto:`
- Links in general should start from `http://`

Setting window location based on the link clicked. 
New class names for HTML elements. 
