### PR TITLE
DCC 5282 - Cannot deselect Cancer Gene Census once selected

### DIFF
--- a/dcc-portal-ui/app/scripts/facets/views/curatedtags.html
+++ b/dcc-portal-ui/app/scripts/facets/views/curatedtags.html
@@ -12,7 +12,7 @@
         <ul>
              <li data-ng-repeat="item in predefinedCurated"
                  data-ng-if="actives.indexOf(item.id) >= 0"
-                 data-ng-click="removeTerm({'type':type, 'facetName': facetName, 'id':item.id})"
+                 data-ng-click="removeTerm(item.id)"
                  class="t_facets__facet__terms__active__term__label"
                  data-ng-mouseover="toggleRemove=true"
                  data-ng-mouseleave="toggleRemove=false">


### PR DESCRIPTION
`removeTerm` function expects an id not an object. So passing the ID instead of a Object
