### PR TITLE
Remove unused class .sticky-scrollfix from repo page heading. fixes DCC-5329

### DIFF
--- a/dcc-portal-ui/app/scripts/repository/views/repository.external.html
+++ b/dcc-portal-ui/app/scripts/repository/views/repository.external.html
@@ -1,5 +1,5 @@
 <div class="h1-wrap">
-    <h1 data-ui-scrollfix="79" class="sticky-scrollfix">
+    <h1 data-ui-scrollfix="79">
         <span class="t_badge t_badge_icon t_badge__data_repositories">
           <span class="icon-download-cloud" />
         </span>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/743976/19092860/b7696768-8a56-11e6-887e-cf3dedb274c3.png)

Checked that sticky heading still works
