### PR TITLE
Update readme, package.json

### DIFF
--- a/dcc-portal-ui/.gitignore
+++ b/dcc-portal-ui/.gitignore
@@ -4,5 +4,4 @@ app/styles/bootstrap.css
 report/
 app/scripts/common/js/pql/pqlparser.js
 target/
-test-bower*
 translations/*.mo

--- a/dcc-portal-ui/README.md
+++ b/dcc-portal-ui/README.md
@@ -5,12 +5,6 @@ Requiments
 ---
 
 - Install [node.js](http://nodejs.org/download/ )
-- Install global modules:
-
-	```
-	npm install -g bower@1.3.12
-	npm install -g bower-art-resolver
-	```
 
 Setup
 ---

--- a/dcc-portal-ui/README.md
+++ b/dcc-portal-ui/README.md
@@ -215,9 +215,6 @@ Angular makes the controller available via the **$scope** variable irregardless 
 * An example of a module called projects in a file called projects.js
 
     ```javascript
-    (function () {
-      'use strict';
-
       // Projects modules definition including dependencies
       angular.module('session', ['session.controllers', 'ui.router'])
           .constant('sessionConstants', {
@@ -236,8 +233,6 @@ Angular makes the controller available via the **$scope** variable irregardless 
           .run(function(someDependency1, someDependency1, ..., someDependencyN) {
             /* ... Run block implementation ... */
           });
-
-    })();
     ```
 
 
@@ -273,9 +268,6 @@ you can do it inline as long as it does not span more then 3 lines.
 * A Good Example
 
     ```javascript
-      (function() {
-        'use strict';
-
         angular.module('session.controllers', [])
            /**
             * This controller does ...
@@ -317,7 +309,6 @@ you can do it inline as long as it does not span more then 3 lines.
           .controller('FixedSessionCtrl', function(someService) {
             /* ... */
           });
-    })();
     ```
 
 * If you must use ```$scope``` in your controllers/directives ensure that you are at least encapsulating your
@@ -328,9 +319,6 @@ you might run into with child scopes used in forms, subcontrollers, and directiv
 * A Bad Example
 
     ```javascript
-        (function() {
-            'use strict';
-
             angular.module('sessions.controller')
               .controller(function($scope) {
                 var _controller = this;
@@ -341,14 +329,10 @@ you might run into with child scopes used in forms, subcontrollers, and directiv
 
                 /* ... */
               });
-        })();
     ```
 * A Good Example
 
     ```javascript
-        (function() {
-            'use strict';
-
             angular.module('users.controllers')
               .controller('UserCtrl', function($scope) {
 
@@ -363,7 +347,6 @@ you might run into with child scopes used in forms, subcontrollers, and directiv
 
                 /* ... */
               });
-        })();
     ```
 
 Before Pull Request

--- a/dcc-portal-ui/README.md
+++ b/dcc-portal-ui/README.md
@@ -5,12 +5,9 @@ Requiments
 ---
 
 - Install [node.js](http://nodejs.org/download/ )
-- Install ruby
-- Install rubygems
 - Install global modules:
 
 	```
-	npm install -g grunt-cli@0.1.13
 	npm install -g bower@1.3.12
 	npm install -g bower-art-resolver
 	```
@@ -18,23 +15,11 @@ Requiments
 Setup
 ---
 
-- Install local modules
+- Install npm and bower dependencies
 
 	```
 	npm install
-	```
-	
-- Install client-side dependencies	
-	```
-	npm install -g bower
-	bower install
-	```
-	
-- Install ruby gems
-
-	```
-	sudo gem install bundler -v 1.5.3
-	bundle install
+    # bower dependencies are auto-installed via the postinstall hook script
 	```
 
 Run
@@ -44,10 +29,7 @@ Run
 
 - Start the [Portal Server](../dcc-portal-server/README.md)
 
-- View the site: [localhost:9000](http://localhost:9000/)
-
-- You can change some of the front end develop options (used `grunt server`) by modifying the `app/develop/scripts/config.js` file.
-
+- View the site: [localhost:9000](http://local.dcc.icgc.org:9000/)
 
 ## Basic Style Guide
 
@@ -154,14 +136,11 @@ its entirety or none at all.
         var _theMeaningOfLife = 42;
     ```
 
-### Keeping your Code Private + Code Commenting and Documentation
+### Code Commenting and Documentation
 
 * The bad example - contents of secrets.js
 
     ```javascript
-       // Without a function closure this becomes global (added to the window object in the browser!)
-       var _theMeaningOfLife = 42;
-
        // What does this method do?
        function meaningOfLife(meaningOfLifeVal) {
           // ... some implementation details
@@ -174,35 +153,15 @@ its entirety or none at all.
 * The good example - contents of secrets.js
 
     ```javascript
-       /**
-        * Anonymous executed function - use this comment style for multiline comments
-        * its also useful for documenting your functions - we use jsDoc syntax
-        * http://usejsdoc.org/about-getting-started.html
-        **/
-
-       (function() {
-            /**
-            * You should always include this little guy - it will tell your browser to be more
-            * watchful for common JS issues.
-            **/
-           'use strict';
-
-           // without a function closure this becomes global (added to the window object in the browser!)
-           var _theMeaningOfLife = 42;
-
-          /**
-           * Gets and sets the meaning of Life (this is a method description that is picked up by jsdocs).
-           * @param {string} meaningOfLifeVal - The new meaning of life.
-           * @returns {string} The current meaning of life.
-           */
-           function meaningOfLife(meaningOfLifeVal) {
-              // ...
-              return _theMeaningOfLife;
-           }
-
-           /* ... Some code ... */
-
-       })();
+        /**
+        * Gets and sets the meaning of Life (this is a method description that is picked up by jsdocs).
+        * @param {string} meaningOfLifeVal - The new meaning of life.
+        * @returns {string} The current meaning of life.
+        */
+        function meaningOfLife(meaningOfLifeVal) {
+            // ...
+            return _theMeaningOfLife;
+        }
     ```
 
 

--- a/dcc-portal-ui/package.json
+++ b/dcc-portal-ui/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com:icgc-dcc/dcc-portal.git"
   },
   "scripts": {
-    "bower": "bower install",
+    "postinstall": "bower install",
     "sethost": "hostile set localhost local.dcc.icgc.org",
     "unsethost": "hostile remove local.dcc.icgc.org",
     "checkhost": "node tasks/checkDns.js",

--- a/dcc-portal-ui/package.json
+++ b/dcc-portal-ui/package.json
@@ -16,8 +16,6 @@
     "dev": "npm start",
     "dev:prodapi": "API_SOURCE=production npm run dev",
     "font:open": "fontello-cli --config app/styles/fonts/config.json open",
-    "test-bower": "rm -rf app/bower_components/ && rm -rf ~/.cache/bower/ && bower install -V 2>&1 | tee test-bower-$(date +%Y%m%d%H%M%S).txt && cat app/bower_components/angular/bower.json | grep version",
-    "--build": "webpack --verbose --colors --display-error-details --config tasks/webpackConfig.js",
     "build": "node ./tasks/build.js",
     "start": "node ./tasks/start.js",
     "test": "karma start karma.conf.js",

--- a/dcc-portal-ui/pom.xml
+++ b/dcc-portal-ui/pom.xml
@@ -108,21 +108,6 @@
             </configuration>
           </execution>
           <execution>
-            <id>bower-install</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <executable>npm</executable>
-              <arguments>
-                <argument>run</argument>
-                <argument>bower</argument>
-              </arguments>
-              <workingDirectory>.</workingDirectory>
-            </configuration>
-          </execution>
-          <execution>
             <id>npm-build</id>
             <phase>compile</phase>
             <goals>


### PR DESCRIPTION
Remove installation instructions for unused dependencies from README.md (grunt, ruby)

Removed instructions to use IIFEs as they are are no longer necessary (nothing will leak into global unless explicitly set onto `global` or `window`)

Bower no longer needs to be globally installed, `bower install` is also now automatically triggerd by `npm install`. New dependencies should be installed via npm. All client dependencies are installed by running `npm install`

(Not yet moving to yarn due to our dependency on bower and yarn's current [problems with bower](https://github.com/yarnpkg/yarn/pull/896) (deletes everything in the bower_components folder after install, so manual `bower install` needs to be run) and lack of support for postinstall hooks ([merged](https://github.com/yarnpkg/yarn/pull/800) but not yet published))

Removed npm tasks for bower testing (seems to have stabilized)
