### PR TITLE
Feature/dcc 5243 no cookies

### DIFF
--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/GenericExceptionMapper.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/jersey/mapper/GenericExceptionMapper.java
@@ -20,6 +20,7 @@ package org.icgc.dcc.portal.server.jersey.mapper;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static javax.ws.rs.core.Response.serverError;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static org.icgc.dcc.portal.server.util.HttpServletRequests.getHeadersFromRequest;
 import static org.icgc.dcc.portal.server.util.HttpServletRequests.getHttpRequestCallerInfo;
 
 import java.util.Date;
@@ -130,8 +131,11 @@ public class GenericExceptionMapper implements ExceptionMapper<Throwable> {
     try {
       val report = new BufferedReport();
       report.addException((Exception) t);
-      report.addInfo("Info", getHttpRequestCallerInfo(request));
-      report.addInfo("Request = %s", request);
+      report.addInfo("Info = %s", getHttpRequestCallerInfo(request));
+      report.addInfo("Request URL = %s", request.getRequestURI());
+      report.addInfo("Request Method = %s", request.getMethod());
+      report.addInfo("Request Query String = %s", request.getQueryString());
+      report.addInfo("Request Headers= %s", getHeadersFromRequest(request));
       report.addInfo("Date = %s", new Date());
 
       val email = new ReportEmail("DCC Portal", report);

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/security/AuthResource.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/security/AuthResource.java
@@ -54,6 +54,7 @@ import org.icgc.dcc.portal.server.config.ServerProperties.CrowdProperties;
 import org.icgc.dcc.portal.server.model.User;
 import org.icgc.dcc.portal.server.resource.Resource;
 import org.icgc.dcc.portal.server.security.AuthService;
+import org.icgc.dcc.portal.server.service.BadRequestException;
 import org.icgc.dcc.portal.server.service.CmsAuthService;
 import org.icgc.dcc.portal.server.service.SessionService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -340,10 +341,15 @@ public class AuthResource extends Resource {
    * @return sessionToken or <tt>null</tt> if no token found
    */
   private static UUID getSessionToken(HttpServletRequest request) {
-    for (val cookie : request.getCookies()) {
-      if (isSessionTokenCookie(cookie)) {
-        return stringToUuid(cookie.getValue());
+    val cookies = request.getCookies();
+    if (cookies != null) {
+      for (val cookie : cookies) {
+        if (isSessionTokenCookie(cookie)) {
+          return stringToUuid(cookie.getValue());
+        }
       }
+    } else {
+      throw new BadRequestException("Cookies must be set for this resource.");
     }
 
     return null;

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/util/HttpServletRequests.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/util/HttpServletRequests.java
@@ -19,17 +19,18 @@ package org.icgc.dcc.portal.server.util;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_FOR;
+import static java.lang.String.format;
 import static lombok.AccessLevel.PRIVATE;
 
 import java.net.InetAddress;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.google.common.base.Joiner;
+
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.val;
-
-import com.google.common.base.Joiner;
 
 /**
  * HttpServletRequest-related helpers
@@ -52,6 +53,22 @@ public final class HttpServletRequests {
 
     return JOINER.join(intro, getLocalNetworkInfo(), getRemoteUserNetworkInfo(request),
         getProxyNetworkInfo(request));
+  }
+
+  public static String getHeadersFromRequest(@NonNull final HttpServletRequest request) {
+    val headers = new StringBuilder();
+
+    val headerNames = request.getHeaderNames();
+    while (headerNames.hasMoreElements()) {
+      val name = headerNames.nextElement();
+      val values = request.getHeaders(name);
+      while (values.hasMoreElements()) {
+        val value = values.nextElement();
+        headers.append(format("%s : %s ;\n", name, value));
+      }
+    }
+
+    return headers.toString();
   }
 
   private static String formatNetworkInfo(final String hostName, final String ipAddress) {


### PR DESCRIPTION
Fixes 500 errors when hitting auth endpoint with no cookies. 

Also improves info portion of emails generated by 500s:
![screen shot 2016-10-19 at 11 48 48 am](https://cloud.githubusercontent.com/assets/6350043/19526408/5e77e024-95f2-11e6-9631-8ada506a1fe3.png)
