### PR TITLE
Bugfix: saving sets in different tabs overwrite sets saved in other tabs

### DIFF
--- a/dcc-portal-ui/app/scripts/sets/js/services.js
+++ b/dcc-portal-ui/app/scripts/sets/js/services.js
@@ -211,6 +211,7 @@
 
         data.type = data.type.toLowerCase();
 
+        setList = localStorageService.get(LIST_ENTITY) || [];
         setList.unshift(data);
         _service.refreshList();
 
@@ -248,6 +249,7 @@
 
         data.type = data.type.toLowerCase();
 
+        setList = localStorageService.get(LIST_ENTITY) || [];
         setList.unshift(data);
         _service.refreshList();
 
@@ -363,6 +365,7 @@
 
         data.type = data.type.toLowerCase();
 
+        setList = localStorageService.get(LIST_ENTITY) || [];
         setList.unshift(data);
         _service.refreshList();
 

--- a/dcc-portal-ui/app/scripts/sets/js/services.js
+++ b/dcc-portal-ui/app/scripts/sets/js/services.js
@@ -422,6 +422,7 @@
 
     /****** Local storage related API ******/
     _service.getAll = function() {
+      setList = localStorageService.get(LIST_ENTITY) || [];
       return setList;
     };
 


### PR DESCRIPTION
Saving sets will no longer overwrite sets saved in other tabs
