### PR TITLE
no hard refresh on filter change in repos

### DIFF
--- a/dcc-portal-ui/app/scripts/repository/js/routes.js
+++ b/dcc-portal-ui/app/scripts/repository/js/routes.js
@@ -32,6 +32,7 @@
 
     $stateProvider.state ('dataRepositories', {
       url: '/repositories?filters',
+      reloadOnSearch: false,
       templateUrl: '/scripts/repository/views/repository.external.html',
       controller: 'ExternalRepoController as ExternalRepoController'
     });


### PR DESCRIPTION
This may have been the cause of a lot of issues. On any filter change it would blow away the current scope/controller and re-instantiate everything. 

We should test thoroughly. 
