### PR TITLE
DCC 5308 Portal UI - Gene Page, mutation table pushed too wide as a result of long string in the DNA Change column

### DIFF
--- a/dcc-portal-ui/app/scripts/genes/views/gene.html
+++ b/dcc-portal-ui/app/scripts/genes/views/gene.html
@@ -422,10 +422,11 @@
             <tbody>
             <tr data-ng-repeat="mutation in GeneMutationsCtrl.mutations.hits track by mutation.id">
                 <td><a data-ng-href="/mutations/{{ mutation.id }}">{{ mutation.id }}</a></td>
-                <td style="text-overflow:ellipsis;width:11em;display:block;overflow:hidden;"
-                    data-tooltip="chr{{mutation.chromosome}}:g.{{mutation.start}}{{mutation.mutation}}"
+                <td data-tooltip="chr{{mutation.chromosome}}:g.{{mutation.start}}{{mutation.mutation}}"
                     data-tooltip-placement="top">
-                    chr{{mutation.chromosome}}:g.{{mutation.start}}{{mutation.mutation}}
+                    <span style="text-overflow:ellipsis;width:11em;display:block;overflow:hidden;">
+                        chr{{mutation.chromosome}}:g.{{mutation.start}}{{mutation.mutation}}
+                    </span>
                 </td>
                 <td><abbr data-tooltip="{{ mutation.type | define }}">{{ mutation.type }}</abbr></td>
                 <td style="max-width: 20rem; white-space: normal">

--- a/dcc-portal-ui/app/scripts/genes/views/gene.html
+++ b/dcc-portal-ui/app/scripts/genes/views/gene.html
@@ -422,7 +422,11 @@
             <tbody>
             <tr data-ng-repeat="mutation in GeneMutationsCtrl.mutations.hits track by mutation.id">
                 <td><a data-ng-href="/mutations/{{ mutation.id }}">{{ mutation.id }}</a></td>
-                <td>chr{{mutation.chromosome}}:g.{{mutation.start}}{{mutation.mutation}}</td>
+                <td style="text-overflow:ellipsis;width:11em;display:block;overflow:hidden;"
+                    data-tooltip="chr{{mutation.chromosome}}:g.{{mutation.start}}{{mutation.mutation}}"
+                    data-tooltip-placement="top">
+                    chr{{mutation.chromosome}}:g.{{mutation.start}}{{mutation.mutation}}
+                </td>
                 <td><abbr data-tooltip="{{ mutation.type | define }}">{{ mutation.type }}</abbr></td>
                 <td style="max-width: 20rem; white-space: normal">
                     <mutation-consequences data-ng-if="mutation.consequences"


### PR DESCRIPTION
- Fixed width added to DNA Change column on Gene entity page
- Showing text overflow as 'ellipsis'
- Tooltip added to show full text of the data
