### PR TITLE
Exclude files in bower_components and app/vendor from being processed

### DIFF
--- a/dcc-portal-ui/config/paths.js
+++ b/dcc-portal-ui/config/paths.js
@@ -11,5 +11,7 @@ module.exports = {
   appPackageJson: resolveApp('package.json'),
   appSrc: resolveApp('app'),
   appNodeModules: resolveApp('node_modules'),
+  bowerModules: resolveApp('app/bower_components'),
+  internalVendorModules: resolveApp('app/vendor'),
   ownNodeModules: resolveApp('node_modules')
 };

--- a/dcc-portal-ui/config/webpack.config.dev.js
+++ b/dcc-portal-ui/config/webpack.config.dev.js
@@ -5,7 +5,7 @@ var CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 var paths = require('./paths');
 
 module.exports = {
-  devtool: 'source-map',
+  devtool: 'cheap-module-eval-source-map',
   cache: true,
   context: path.resolve(__dirname, '../app/scripts'),
   entry: {

--- a/dcc-portal-ui/config/webpack.config.dev.js
+++ b/dcc-portal-ui/config/webpack.config.dev.js
@@ -6,6 +6,7 @@ var paths = require('./paths');
 
 module.exports = {
   devtool: 'source-map',
+  cache: true,
   context: path.resolve(__dirname, '../app/scripts'),
   entry: {
     app: [

--- a/dcc-portal-ui/config/webpack.config.dev.js
+++ b/dcc-portal-ui/config/webpack.config.dev.js
@@ -55,6 +55,7 @@ module.exports = {
       {
         test: /\.js$/,
         include: paths.appSrc,
+        exclude: [paths.bowerModules, paths.internalVendorModules],
         loaders: ['babel?' + JSON.stringify(require('./babel.dev'))],
       },
       {

--- a/dcc-portal-ui/config/webpack.config.prod.js
+++ b/dcc-portal-ui/config/webpack.config.prod.js
@@ -41,11 +41,13 @@ module.exports = {
       {
         test: /\.js$/,
         include: paths.appSrc,
+        exclude: [paths.bowerModules, paths.internalVendorModules],
         loader: 'ng-annotate',
       },
       {
         test: /\.js$/,
         include: paths.appSrc,
+        exclude: [paths.bowerModules, paths.internalVendorModules],
         loader: 'babel',
         query: require('./babel.prod'),
       },

--- a/dcc-portal-ui/config/webpack.config.prod.js
+++ b/dcc-portal-ui/config/webpack.config.prod.js
@@ -7,7 +7,7 @@ var paths = require('./paths');
 
 module.exports = {
   bail: true,
-  devtool: 'source-map',
+  devtool: 'eval',
   entry: {
     app: [
       require.resolve('./polyfills'),


### PR DESCRIPTION
_should_ somewhat speed up compilation

Would be even better once [this issue](https://github.com/webpack/webpack/issues/1079) is resolved (although not sure when/if it will be, been open fore more than a year)
