### PR TITLE
DCCPRTL 4 - Missing borders on tables

### DIFF
--- a/dcc-portal-ui/app/scripts/advanced/views/advanced.genes.html
+++ b/dcc-portal-ui/app/scripts/advanced/views/advanced.genes.html
@@ -58,7 +58,7 @@
             <td>{{ gene.name }}</td>
             <td>chr{{gene.chromosome}}:{{gene.start}}-{{gene.end}}</td>
             <td>{{ gene.type | trans }}</td>
-            <td class="text-right" style="display:block; position: relative; white-space: nowrap">
+            <td class="text-right" style="position: relative; white-space: nowrap">
                         <span style="position: relative" data-ng-if="gene.affectedDonorCountFiltered > 0">
                         <a href='/search?filters={{gene.embedQuery}}'>
                             {{gene.affectedDonorCountFiltered | number}}

--- a/dcc-portal-ui/app/scripts/advanced/views/advanced.mutations.mutations.html
+++ b/dcc-portal-ui/app/scripts/advanced/views/advanced.mutations.mutations.html
@@ -47,9 +47,9 @@
         <td style="max-width: 15rem; white-space: normal">
             <mutation-consequences  items="mutation.consequences"></mutation-consequences>
         </td>
-        <td class="text-right" style="position: relative; display: block;white-space: nowrap">
+        <td class="text-right" style="position: relative; white-space: nowrap">
                         
-                    <span style="position: relative">
+                    <span style="position: relative;display: block;">
                         <a href='/search?filters={{mutation.embedQuery}}'>
                             {{mutation.affectedDonorCountFiltered | number}}
                         </a>

--- a/dcc-portal-ui/app/scripts/compounds/views/compound.html
+++ b/dcc-portal-ui/app/scripts/compounds/views/compound.html
@@ -204,7 +204,7 @@
                                 <td data-ng-bind-html="gene.uiName | highlight: CompoundCtrl.tableFilter.targetedGenes"></td>
                                 <td data-ng-bind-html="gene.uiLocation | highlight: CompoundCtrl.tableFilter.targetedGenes"></td>
                                 <td data-ng-bind-html="gene.uiType | highlight: CompoundCtrl.tableFilter.targetedGenes"></td>
-                                <td class="text-right" style="display:block; position: relative; white-space: nowrap">
+                                <td class="text-right" style="position: relative; white-space: nowrap">
                                      <span data-ng-style="{width: gene.uiAffectedDonorCountTotalPercentage}"
                                            class="t_facets__facet__terms__active__term__bar">
                                      </span>

--- a/dcc-portal-ui/app/scripts/donors/views/donor.html
+++ b/dcc-portal-ui/app/scripts/donors/views/donor.html
@@ -312,7 +312,7 @@
                 <td>
                     <mutation-consequences items="mutation.consequences"></mutation-consequences>
                 </td>
-                <td class="text-right" style="position: relative; display: block;white-space: nowrap">
+                <td class="text-right" style="position: relative; white-space: nowrap">
                         <span data-ng-style="{width:mutation.affectedDonorCountFiltered/DonorCtrl.donor.ssmTestedDonorCount * 100+'%'}"
                           class="t_facets__facet__terms__active__term__bar"></span>
                     <span style="position: relative">

--- a/dcc-portal-ui/app/scripts/genesets/views/geneset.html
+++ b/dcc-portal-ui/app/scripts/genesets/views/geneset.html
@@ -406,7 +406,7 @@
                 <td>{{gene.name}}</td>
                 <td>chr{{gene.chromosome}}:{{gene.start}}-{{gene.end}}</td>
                 <td>{{gene.type}}</td>
-                <td class="text-right" style="display:block; position: relative; white-space: nowrap">
+                <td class="text-right" style="position: relative; white-space: nowrap">
                     <span data-ng-style="{width:gene.affectedDonorCountFiltered/GeneSetCtrl.totalDonors * 100+'%'}"
                           class="t_facets__facet__terms__active__term__bar"></span>
                     <span style="position: relative">

--- a/dcc-portal-ui/app/scripts/mutations/views/mutation.html
+++ b/dcc-portal-ui/app/scripts/mutations/views/mutation.html
@@ -241,7 +241,7 @@
                 <td>
                     <span data-ng-bind-html="project.uiTumourSubtype | highlight: MutationCtrl.tableFilter.projects"></span>
                 </td>
-                <td class="text-right" style="display:block; position: relative">
+                <td class="text-right" style="position: relative">
                     <span data-ng-style="{width:project.uiPercentAffected+'%'}"
                           class="t_facets__facet__terms__active__term__bar"></span>
                     <span style="position: relative">

--- a/dcc-portal-ui/app/scripts/projects/views/project.html
+++ b/dcc-portal-ui/app/scripts/projects/views/project.html
@@ -382,7 +382,7 @@
                 <td>{{gene.name}}</td>
                 <td>chr{{gene.chromosome}}:{{gene.start}}-{{gene.end}}</td>
                 <td>{{gene.type | trans}}</td>
-                <td class="text-right" style="display:block; position: relative; white-space: nowrap">
+                <td class="text-right" style="position: relative; white-space: nowrap">
 
                         <span
                             data-ng-style="{width:gene.affectedDonorCountFiltered/ProjectCtrl.project.ssmTestedDonorCount * 100+'%'}"


### PR DESCRIPTION
Removed `display:block` css code from table columns to show proper borders
