### PR TITLE
Have webpack dev server optionally proxy to production api 

### DIFF
--- a/dcc-portal-ui/README.md
+++ b/dcc-portal-ui/README.md
@@ -33,6 +33,20 @@ Run
 
 - View the site: [localhost:9000](http://local.dcc.icgc.org:9000/)
 
+Other Commands
+---
+
+```bash
+# Connect to the production server's API instead of a local backend
+npm run dev:prodapi
+
+# Adds local.dcc.icgc.org to your host file and point to localhost
+npm run sethost
+
+# Open fontello with the project's json config loaded
+npm run font:open
+```
+
 ## Basic Style Guide
 
 

--- a/dcc-portal-ui/tasks/start.js
+++ b/dcc-portal-ui/tasks/start.js
@@ -156,10 +156,16 @@ function runDevServer(port) {
       ignored: /node_modules/
     },
     proxy: {
-      '/api/*': {
-        target: 'http://localhost:8080',
-        secure: false,
-      },
+      '/api/**': process.env.API_SOURCE === 'production'
+        ? {
+          target: 'https://dcc.icgc.org/',
+          secure: false,
+          changeOrigin: true,
+        }
+        : {
+          target: 'http://localhost:8080',
+          secure: false,
+        },
       '/(scripts|styles|vendor|bower_components)/**': {
         target: 'http://localhost:9000/app',
         secure: false,


### PR DESCRIPTION
Previously a grunt task, this was not re-implemented following build tool move to webpack until now

Usage remains the same via:  

```bash
npm run dev:prodapi
```