### PR TITLE
DCCPRTL 56 Reset pagination on filter change

### DIFF
--- a/dcc-portal-ui/app/scripts/advanced/js/advanced.js
+++ b/dcc-portal-ui/app/scripts/advanced/js/advanced.js
@@ -274,12 +274,6 @@ angular.module('icgc.advanced.controllers', [
             return;
           }
 
-          let tab = _controller.getActiveTab();
-          if(tab === 'mutation'){
-            tab = _controller.getActiveSubTab();
-          }
-          LocationService.goToFirstPage(`${tab}s`);
-
           _locationFilterCache.updateCache();
           _resetServices();
           _refresh();

--- a/dcc-portal-ui/app/scripts/advanced/js/advanced.js
+++ b/dcc-portal-ui/app/scripts/advanced/js/advanced.js
@@ -54,7 +54,7 @@ angular.module('icgc.advanced.controllers', [
     'icgc.advanced.services', 'icgc.sets.services', 'icgc.facets'])
     .controller('AdvancedCtrl',
     function ($scope, $rootScope, $state, $modal, Page, AdvancedSearchTabs, LocationService, AdvancedDonorService, // jshint ignore:line
-              AdvancedGeneService, AdvancedMutationService, SetService, CodeTable, Settings, Restangular,
+              AdvancedGeneService, AdvancedMutationService, SetService, CodeTable, Settings, Restangular, FilterService,
               RouteInfoService, FacetConstants, Extensions, gettextCatalog) {
 
       var _controller = this,
@@ -267,13 +267,18 @@ angular.module('icgc.advanced.controllers', [
         });
 
         $scope.$on(_filterService.constants.FILTER_EVENTS.FILTER_UPDATE_EVENT, function(e, filterObj) {
-
           if (filterObj.currentPath.indexOf('/search') < 0) {
             // Unfortunately this event fired before a state change notification is posted so this
             // provides a better why to determine if we need to abort requests that have been made.
             //Restangular.abortAllHTTPRequests();
             return;
           }
+
+          let tab = _controller.getActiveTab();
+          if(tab === 'mutation'){
+            tab = _controller.getActiveSubTab();
+          }
+          LocationService.goToFirstPage(`${tab}s`);
 
           _locationFilterCache.updateCache();
           _resetServices();
@@ -480,6 +485,8 @@ angular.module('icgc.advanced.controllers', [
         _controller.state.setSubTab(tab);
       };
 
+      _controller.getActiveSubTab = () =>_controller.state.getSubTab();
+
       /**
        * View observation/experimental details
        */
@@ -494,7 +501,6 @@ angular.module('icgc.advanced.controllers', [
           }
         });
       };
-
 
       _init();
     })

--- a/dcc-portal-ui/app/scripts/advanced/js/advanced.js
+++ b/dcc-portal-ui/app/scripts/advanced/js/advanced.js
@@ -54,7 +54,7 @@ angular.module('icgc.advanced.controllers', [
     'icgc.advanced.services', 'icgc.sets.services', 'icgc.facets'])
     .controller('AdvancedCtrl',
     function ($scope, $rootScope, $state, $modal, Page, AdvancedSearchTabs, LocationService, AdvancedDonorService, // jshint ignore:line
-              AdvancedGeneService, AdvancedMutationService, SetService, CodeTable, Settings, Restangular, FilterService,
+              AdvancedGeneService, AdvancedMutationService, SetService, CodeTable, Settings, Restangular,
               RouteInfoService, FacetConstants, Extensions, gettextCatalog) {
 
       var _controller = this,
@@ -478,8 +478,6 @@ angular.module('icgc.advanced.controllers', [
       _controller.setSubTab = function (tab) {
         _controller.state.setSubTab(tab);
       };
-
-      _controller.getActiveSubTab = () =>_controller.state.getSubTab();
 
       /**
        * View observation/experimental details

--- a/dcc-portal-ui/app/scripts/ui/js/table.js
+++ b/dcc-portal-ui/app/scripts/ui/js/table.js
@@ -140,7 +140,8 @@ angular.module('icgc.ui.table.pagination', [])
     maxSize: 5
   })
 
-  .directive('paginationControls', function (paginationConfig, LocationService, $filter, gettextCatalog) {
+  .directive('paginationControls', function (paginationConfig, LocationService, $filter, 
+    $rootScope, FilterService, gettextCatalog) {
     return {
       restrict: 'E',
       scope: {
@@ -269,6 +270,10 @@ angular.module('icgc.ui.table.pagination', [])
             LocationService.setJsonParam('from', from);
           }
         };
+
+        $rootScope.$on(FilterService.constants.FILTER_EVENTS.FILTER_UPDATE_EVENT, () => {
+          scope.updateParams(scope.type, 1);
+        });
       }
     };
   })


### PR DESCRIPTION
Updating filter parameters in pagination directive rather then on a particular page itself. These changes will make sure to reset all the pagination scope on a particular page regardless what type of filter was added/removed.

This might override the changes that were made in PR #160 