### PR TITLE
Adds "id" to field mapping.

### DIFF
--- a/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/FileTypeModel.java
+++ b/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/FileTypeModel.java
@@ -252,6 +252,7 @@ public class FileTypeModel extends TypeModel {
   public static final List<String> PUBLIC_FIELDS = ImmutableList.of(
       Fields.OBJECT_ID,
       Fields.FILE_UUID,
+      Fields.ID,
       Fields.FILE_ID,
       Fields.FILE_COPIES,
       Fields.DONORS,


### PR DESCRIPTION
This fixes saving file sets as the API could not support sorting by ID due to the TypeModel backed field mapping missing the ID in the mapping. 