### PR TITLE
DCC 51518 Export Mutation occurrences table - Rename column header to "Mutation ID" instead of "ID"

### DIFF
--- a/dcc-portal-ui/app/scripts/advanced/views/advanced.mutations.observations.html
+++ b/dcc-portal-ui/app/scripts/advanced/views/advanced.mutations.observations.html
@@ -86,7 +86,7 @@
     <table id="occurrences" class="hidden" data-ng-if="AdvancedCtrl.Page.isExporting()">
         <thead>
         <tr>
-            <th>ID</th>
+            <th>Mutation ID</th>
             <th><translate>Donor ID</translate></th>
             <th><translate>Project</translate></th>
             <th><translate>DNA change</translate></th>


### PR DESCRIPTION
Change header to "Mutation ID" instead of "ID"