### PR TITLE
Adds guard against no intervals, does not compute if only 1 data point.

### DIFF
--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/analysis/SurvivalAnalyzer.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/analysis/SurvivalAnalyzer.java
@@ -130,7 +130,8 @@ public class SurvivalAnalyzer {
     SearchHit[] hits = response.getHits().getHits();
     val donors = filterDonors(hits, filter);
 
-    val intervals = donors.length == 0 ? Collections.<Interval> emptyList() : compute(donors, diseaseFree);
+    // Cannot produce curve with one data point.
+    val intervals = donors.length <= 1 ? Collections.<Interval> emptyList() : compute(donors, diseaseFree);
     return Maps.immutableEntry(hits.length, intervals);
   }
 
@@ -167,6 +168,11 @@ public class SurvivalAnalyzer {
     float atRisk = time.length;
     float cumulativeSurvival = 1;
     val intervalIter = intervals.iterator();
+
+    // Guard with short return if no intervals in iterator.
+    if (!intervalIter.hasNext()) {
+      return intervals;
+    }
 
     // This implementation later mutates this reference.
     Interval currentInterval = intervalIter.next();


### PR DESCRIPTION
Verified with the data that caused the exception:

```json
// SELECT * FROM survival_analysis WHERE id = '56c49be9-f07c-4722-8fab-b3467e0f5b44';

{
  "id": "56c49be9-f07c-4722-8fab-b3467e0f5b44",
  "entitySetIds": ["f4eedb4c-f6a8-4077-9e41-c737dc7e8c44", "fb676bdc-d291-4df7-860e-d014b38fe16c"],
  "inputCount": 2,
  "version": 2,
  "state": "FINISHED",
  "timestamp": 1478479498670,
  "intersection": false
}

// SELECT * FROM entity_set WHERE id = 'f4eedb4c-f6a8-4077-9e41-c737dc7e8c44' OR id = 'fb676bdc-d291-4df7-860e-d014b38fe16c';

{
  "id": "f4eedb4c-f6a8-4077-9e41-c737dc7e8c44",
  "state": "FINISHED",
  "count": 9,
  "name": "Lung, KRAS",
  "description": "",
  "type": "DONOR",
  "version": 2,
  "timestamp": 1478479449713,
  "subtype": "NORMAL"
}


{
  "id": "fb676bdc-d291-4df7-860e-d014b38fe16c",
  "state": "FINISHED",
  "count": 15,
  "name": "Lung, EMP2",
  "description": "",
  "type": "DONOR",
  "version": 2,
  "timestamp": 1478479480652,
  "subtype": "NORMAL"
}
```