### PR TITLE
Don’t settle one time bindings until analysisResults are done

### DIFF
--- a/dcc-portal-ui/app/scripts/analysis/views/analysis.analysis.html
+++ b/dcc-portal-ui/app/scripts/analysis/views/analysis.analysis.html
@@ -58,22 +58,22 @@
         <div style="padding: 2rem 1rem" data-ng-if="analysisId">
             <div data-ng-if="item.type === 'enrichment'" >
                 <div data-ng-if="!error">
-                    <enrichment-result data-item="::analysisResult"></enrichment-result>
+                    <enrichment-result data-item="::(analysisResult.results ? analysisResult : undefined)"></enrichment-result>
                 </div>
             </div>
             <div data-ng-if="item.type === 'set' || item.type === 'union'">
                 <div data-ng-if="!error">
-                    <set-operation data-item="::analysisResult"></set-operation>
+                    <set-operation data-item="::(analysisResult.result ? analysisResult : undefined)"></set-operation>
                 </div>
             </div>
             <div data-ng-if="item.type === 'phenotype'">
                 <div data-ng-if="!error">
-                    <phenotype-result data-item="::analysisResult"></phenotype-result>
+                    <phenotype-result data-item="::(analysisResult.results ? analysisResult : undefined)"></phenotype-result>
                 </div>
             </div>
             <div data-ng-if="item.type === 'oncogrid'">
                 <div data-ng-if="!error">
-                    <oncogrid-analysis data-item="::analysisResult"></oncogrid-analysis>
+                    <oncogrid-analysis data-item="::(analysisResult.state === 'FINISHED' ? analysisResult : undefined)"></oncogrid-analysis>
                 </div>
             </div>
             <div class="clearfix"></div>

--- a/dcc-portal-ui/app/scripts/oncogrid/js/directive.js
+++ b/dcc-portal-ui/app/scripts/oncogrid/js/directive.js
@@ -291,8 +291,8 @@
           gridDiv.addClass('og-pointer-mode'); gridDiv.removeClass('og-crosshair-mode');
         };
 
-        $scope.$watch('item', function (n) {
-          if (n) {
+        function processItem() {
+          if ($scope.item) {
             var getName = type => _(localStorageService.get('entity'))
                             .filter( e => e.id === $scope.item[type])
                             .map( e => e.name)
@@ -321,7 +321,10 @@
               $('#grid-button').addClass('active');
             });
           }
-        });
+        }
+
+        $scope.$watch('item', processItem);
+        processItem();
 
         $scope.fullScreenHandler = function () {
           if (!document.fullscreenElement && !document.mozFullScreenElement && !document.webkitFullscreenElement) {

--- a/dcc-portal-ui/app/scripts/oncogrid/js/directive.js
+++ b/dcc-portal-ui/app/scripts/oncogrid/js/directive.js
@@ -292,7 +292,9 @@
         };
 
         function processItem() {
-          if ($scope.item) {
+          if (!$scope.item) {
+            return;
+          }
             var getName = type => _(localStorageService.get('entity'))
                             .filter( e => e.id === $scope.item[type])
                             .map( e => e.name)
@@ -320,7 +322,6 @@
               $scope.initOnco();
               $('#grid-button').addClass('active');
             });
-          }
         }
 
         $scope.$watch('item', processItem);


### PR DESCRIPTION
Ideally GETs would be idempotent, perhaps we could consider refactoring the endpoints to return some error code until it is ready? Would be easier/cleaner to have a general solution for a status code than to check independently for whether a result is a finished (whether `results` or `result` is truthy, whether `state` is `"FINISHED"`)

What exact code to use seems to be contentious, found some discussion here
http://stackoverflow.com/questions/9794696/how-do-i-choose-a-http-status-code-in-rest-api-for-not-ready-yet-try-again-lat

If feasible, the `Retry-After` header would also be preferable to polling