### PR TITLE
Pre-gzip built files

### DIFF
--- a/dcc-portal-ui/config/webpack.config.prod.js
+++ b/dcc-portal-ui/config/webpack.config.prod.js
@@ -3,6 +3,7 @@ var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
+var CompressionPlugin = require('compression-webpack-plugin');
 var paths = require('./paths');
 
 module.exports = {
@@ -135,5 +136,12 @@ module.exports = {
     }),
     new webpack.optimize.CommonsChunkPlugin(/* chunkName= */"vendor", /* filename= */"vendor.bundle.js"),
     new ExtractTextPlugin('static/css/[name].[contenthash:8].css'),
+    new CompressionPlugin({
+      asset: "[path].gz[query]",
+      algorithm: "gzip",
+      test: /\.js$|\.html$/,
+      threshold: 10240,
+      minRatio: 0.8
+    }),
   ]
 };

--- a/dcc-portal-ui/package.json
+++ b/dcc-portal-ui/package.json
@@ -52,6 +52,7 @@
     "case-sensitive-paths-webpack-plugin": "1.1.4",
     "chalk": "1.1.3",
     "compass-mixins": "0.12.10",
+    "compression-webpack-plugin": "0.3.2",
     "connect-livereload": "0.5.0",
     "connect-modrewrite": "0.5.6",
     "copy-webpack-plugin": "3.0.1",


### PR DESCRIPTION
Dunno how much value there is in this but figures it wouldn't hurt, maybe?

![image](https://cloud.githubusercontent.com/assets/743976/20364194/35e96e3c-ac10-11e6-89c0-5460bdb25ee5.png)

Statically gzips built files to save cpu cycles (although I suppose the gzipped files could be cached, idk)