### PR TITLE
Add { "omitLastInOneLineBlock": true} to eslintrc

### DIFF
--- a/dcc-portal-ui/.eslintrc.json
+++ b/dcc-portal-ui/.eslintrc.json
@@ -97,7 +97,7 @@
             }
         ],
         "new-parens": "warn",
-        "semi": ["warn", "always"],
+        "semi": ["warn", "always", { "omitLastInOneLineBlock": true }],
         "no-array-constructor": "warn",
         "no-caller": "warn",
         "no-cond-assign": [


### PR DESCRIPTION
Semis should be omit-able in single line arrow functions

e.g. `sets => { _this.selectedSets = sets };` should be fine

(current config requires `sets => { _this.selectedSets = sets; };`)