### PR TITLE
Scope DOM selections to within current element for oncogrid directive

### DIFF
--- a/dcc-portal-ui/app/scripts/oncogrid/js/controller.js
+++ b/dcc-portal-ui/app/scripts/oncogrid/js/controller.js
@@ -20,7 +20,7 @@
 
     var module = angular.module('icgc.oncogrid.controllers', []);
 
-    module.controller('OncogridController', function($scope, LocationService, OncogridService, SetService,
+    module.controller('OncogridController', function($scope, $element, LocationService, OncogridService, SetService,
         $timeout, $modal, Extensions, Settings, FullScreenService) {
         var _this = this;
 
@@ -88,7 +88,7 @@
             $scope.crosshairMode = $scope.crosshairMode ? false : true;
             $('#og-crosshair-message').toggle();
             $('#crosshair-button').toggleClass('active');
-            var gridDriv = $('#oncogrid-div');
+            var gridDriv = $element.find('#oncogrid-div');
             gridDriv.toggleClass('og-pointer-mode'); 
             gridDriv.toggleClass('og-crosshair-mode');
             _this.grid.toggleCrosshair();

--- a/dcc-portal-ui/app/scripts/oncogrid/js/directive.js
+++ b/dcc-portal-ui/app/scripts/oncogrid/js/directive.js
@@ -37,7 +37,7 @@
       controller: 'OncogridController',
       controllerAs: 'OncoCtrl',
       templateUrl: '/scripts/oncogrid/views/oncogrid-analysis.html',
-      link: function ($scope) {
+      link: function ($scope, $element) {
         var donorSearch = '/search?filters=';
         var geneSearch = '/search/g?filters=';
         var obsSearch = '/search/m/o?filters=';
@@ -268,7 +268,7 @@
             donors: donors,
             genes: genes,
             observations: observations,
-            element: '#oncogrid-div',
+            element: $element.find('#oncogrid-div').get(0),
             height: 150,
             width: 680,
             colorMap: colorMap,
@@ -303,7 +303,7 @@
           $('#grid-button').removeClass('active');
 
           $('#og-crosshair-message').hide();
-          var gridDiv = $('#oncogrid-div');
+          var gridDiv = $element.find('#oncogrid-div');
           gridDiv.addClass('og-pointer-mode'); 
           gridDiv.removeClass('og-crosshair-mode');
         };
@@ -323,10 +323,10 @@
               $scope.cleanActives();
               $scope.OncoCtrl.grid.destroy();
             }
-            $('#oncogrid-spinner').toggle(true);
+            $element.find('#oncogrid-spinner').toggle(true);
             createLinks();
             $scope.materializeSets().then(function () {
-              $('#oncogrid-spinner').toggle(false);
+              $element.find('#oncogrid-spinner').toggle(false);
 
               // Temporary fix:
               //http://stackoverflow.com/a/23444942


### PR DESCRIPTION
Fixes bug for subsequent oncogrids being rendered into the first DOM element that matches the given selector