### PR TITLE
Revert "DCCPRTL 56 Reset pagination on filter change (#221)"

### DIFF
--- a/dcc-portal-ui/app/scripts/ui/js/table.js
+++ b/dcc-portal-ui/app/scripts/ui/js/table.js
@@ -140,8 +140,7 @@ angular.module('icgc.ui.table.pagination', [])
     maxSize: 5
   })
 
-  .directive('paginationControls', function (paginationConfig, LocationService, $filter, 
-    $rootScope, FilterService, gettextCatalog) {
+  .directive('paginationControls', function (paginationConfig, LocationService, $filter, gettextCatalog) {
     return {
       restrict: 'E',
       scope: {
@@ -270,10 +269,6 @@ angular.module('icgc.ui.table.pagination', [])
             LocationService.setJsonParam('from', from);
           }
         };
-
-        $rootScope.$on(FilterService.constants.FILTER_EVENTS.FILTER_UPDATE_EVENT, () => {
-          scope.updateParams(scope.type, 1);
-        });
       }
     };
   })


### PR DESCRIPTION
This reverts commit 36c9d6404677ca95e17e18c48b9f249e6e16db5c.

This was causing a bug with pagination filters being set on location change to homepage and other pages where it doesn't make sense