### PR TITLE
Change sourcemap during dev from `cheap-module-eval-source-map` to `eval-source-map`

### DIFF
--- a/dcc-portal-ui/config/webpack.config.dev.js
+++ b/dcc-portal-ui/config/webpack.config.dev.js
@@ -5,7 +5,7 @@ var CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 var paths = require('./paths');
 
 module.exports = {
-  devtool: process.env.SOURCE_MAP ? process.env.SOURCE_MAP : 'cheap-module-eval-source-map',
+  devtool: process.env.SOURCE_MAP ? process.env.SOURCE_MAP : 'eval-source-map',
   cache: true,
   context: path.resolve(__dirname, '../app/scripts'),
   entry: {


### PR DESCRIPTION
`cheap-module-eval-source-map` seems to have broken (possible from a chrome update)

Until this is fixed, switch to using the slightly slower `eval-source-map`

Being tracked here:
https://github.com/webpack/webpack/issues/2145

Should switch back to `cheap-module-eval-source-map` once that issue is resolved