### PR TITLE
bugfix: 2 oncogrids showing up

### DIFF
--- a/dcc-portal-ui/app/scripts/oncogrid/js/directive.js
+++ b/dcc-portal-ui/app/scripts/oncogrid/js/directive.js
@@ -326,13 +326,13 @@
 
             $scope.geneSetName = getName('geneSet');
             $scope.donorSetName = getName('donorSet');
-            if (typeof $scope.OncoCtrl.grid !== 'undefined' && $scope.OncoCtrl.grid !== null) {
-              $scope.cleanActives();
-              $scope.OncoCtrl.grid.destroy();
-            }
             $element.find('#oncogrid-spinner').toggle(true);
             createLinks();
             $scope.materializeSets().then(function () {
+              if ($scope.OncoCtrl.grid) {
+                $scope.cleanActives();
+                $scope.OncoCtrl.grid.destroy();
+              }
               $element.find('#oncogrid-spinner').toggle(false);
 
               // Temporary fix:


### PR DESCRIPTION
Race condition where the cleanup was being called before an async action

Moving cleanup to after async action fixes problem