### PR TITLE
Remove one-time binding on enrichment analysis

### DIFF
--- a/dcc-portal-ui/app/scripts/analysis/views/analysis.analysis.html
+++ b/dcc-portal-ui/app/scripts/analysis/views/analysis.analysis.html
@@ -58,7 +58,7 @@
         <div style="padding: 2rem 1rem" data-ng-if="analysisId">
             <div data-ng-if="item.type === 'enrichment'" >
                 <div data-ng-if="!error">
-                    <enrichment-result data-item="::(analysisResult.results ? analysisResult : undefined)"></enrichment-result>
+                    <enrichment-result data-item="analysisResult"></enrichment-result>
                 </div>
             </div>
             <div data-ng-if="item.type === 'set' || item.type === 'union'">


### PR DESCRIPTION
Fixes https://jira.oicr.on.ca/browse/DCCPRTL-93, at the cost of disabling one-time databinding on the enrichment analysis results

The endpoint /api/v1/analysis/enrichment/:uuid returns different data

no results:
returning 200 with results that contain incomplete data 
![image](https://cloud.githubusercontent.com/assets/743976/21063591/685ac0e8-be24-11e6-9fe0-4200953d7a22.png)

results contain counts of 0:
![image](https://cloud.githubusercontent.com/assets/743976/21063596/703303fc-be24-11e6-9ef4-d73f32ae1e01.png)

results contain all data with correct counts:
![image](https://cloud.githubusercontent.com/assets/743976/21063601/79b924a6-be24-11e6-8493-932535e2147c.png)