### PR TITLE
Allow specifying specific url to proxy via API_SOURCE environment variable

### DIFF
--- a/dcc-portal-ui/README.md
+++ b/dcc-portal-ui/README.md
@@ -48,6 +48,9 @@ Other Commands
 # Connect to the production server's API instead of a local backend
 npm run dev:prodapi
 
+# Connect to the staging API instead of local backend
+API_SOURCE=https://staging.dcc.icgc.org npm start
+
 # Adds local.dcc.icgc.org to your host file and point to localhost
 npm run sethost
 

--- a/dcc-portal-ui/tasks/start.js
+++ b/dcc-portal-ui/tasks/start.js
@@ -156,16 +156,16 @@ function runDevServer(port) {
       ignored: /node_modules/
     },
     proxy: {
-      '/api/**': process.env.API_SOURCE === 'production'
-        ? {
-          target: 'https://dcc.icgc.org/',
-          secure: false,
-          changeOrigin: true,
-        }
-        : {
-          target: 'http://localhost:8080',
-          secure: false,
-        },
+      '/api/**': {
+        target: process.env.API_SOURCE
+          ? process.env.API_SOURCE === 'production'
+            ? 'https://dcc.icgc.org/'
+            : process.env.API_SOURCE
+          : 'http://localhost:8080'
+        ,
+        secure: false,
+        changeOrigin: true,
+      },
       '/(scripts|styles|vendor|bower_components)/**': {
         target: 'http://localhost:9000/app',
         secure: false,


### PR DESCRIPTION
Usage：

Connect to the staging API instead of local backend:
```
API_SOURCE=https://staging.dcc.icgc.org npm start
```

Connect to a dev server instance's API:
```
API_SOURCE=https://dev.dcc.icgc.org:8872 npm start
```

Useful for testing new backend features without locally running eclipse