### PR TITLE
Workaround for chrome table bg rendering bug

### DIFF
--- a/dcc-portal-ui/app/styles/_modules/_tables.scss
+++ b/dcc-portal-ui/app/styles/_modules/_tables.scss
@@ -39,7 +39,7 @@ $table-th-fixed-width: 200px;
     tr {
       vertical-align: top;
 
-      &:nth-child(odd) {
+      &:nth-child(odd) td {
         background: $greyLightest;
       }
     }


### PR DESCRIPTION
Move background on alternating row from tr to td