### PR TITLE
DCCPRTL 213 use 301 instead of 404

### DIFF
--- a/dcc-portal-ui/app/scripts/301/js/301.js
+++ b/dcc-portal-ui/app/scripts/301/js/301.js
@@ -17,24 +17,24 @@
 
 'use strict';
 
-angular.module('icgc.304', ['icgc.304.controllers', 'ui.router'])
+angular.module('icgc.301', ['icgc.301.controllers', 'ui.router'])
   .config(function($stateProvider){
-    $stateProvider.state('304', {
-      url: '/304?page',
+    $stateProvider.state('301', {
+      url: '/301?page',
       templateUrl: '/scripts/404/views/404.html',
-      controller: '304Controller as ctrlr'
+      controller: '301Controller as ctrlr'
     });
   });
 
 (function(){
-  angular.module('icgc.304.controllers', [])
-    .controller('304Controller', function($stateParams, Page, $timeout, $window){
+  angular.module('icgc.301.controllers', [])
+    .controller('301Controller', function($stateParams, Page, $timeout, $window){
       const _ctrl = this;
       _ctrl.isRedirect = true;
       _ctrl.pathToGoTo = $stateParams.page;
       _ctrl.timeToRedirect = 5;
 
-      Page.setTitle('304 - Redirecting');
+      Page.setTitle('301 - Redirecting');
       Page.setPage('error');
 
       const processRedirect = () => {

--- a/dcc-portal-ui/app/scripts/301/js/301.js
+++ b/dcc-portal-ui/app/scripts/301/js/301.js
@@ -32,7 +32,7 @@ angular.module('icgc.301', ['icgc.301.controllers', 'ui.router'])
       const _ctrl = this;
       _ctrl.isRedirect = true;
       _ctrl.pathToGoTo = $stateParams.page;
-      _ctrl.timeToRedirect = 5;
+      _ctrl.timeToRedirect = 10;
 
       Page.setTitle('301 - Redirecting');
       Page.setPage('error');

--- a/dcc-portal-ui/app/scripts/304/js/304.js
+++ b/dcc-portal-ui/app/scripts/304/js/304.js
@@ -17,32 +17,37 @@
 
 'use strict';
 
-angular.module('icgc.404', ['icgc.404.controllers', 'ui.router'])
+angular.module('icgc.304', ['icgc.304.controllers', 'ui.router'])
   .config(function($stateProvider){
-    $stateProvider.state('404', {
-      url: '/404?page&id&url',
+    $stateProvider.state('304', {
+      url: '/304?page',
       templateUrl: '/scripts/404/views/404.html',
-      controller: '404Controller as ctrlr'
+      controller: '304Controller as ctrlr'
     });
   });
 
 (function(){
-  angular.module('icgc.404.controllers', [])
-    .controller('404Controller', function($stateParams, Page){
-      var _ctrl = this;
-      _ctrl.info = '';
+  angular.module('icgc.304.controllers', [])
+    .controller('304Controller', function($stateParams, Page, $timeout, $window){
+      const _ctrl = this;
+      _ctrl.isRedirect = true;
+      _ctrl.pathToGoTo = $stateParams.page;
+      _ctrl.timeToRedirect = 5;
 
-      Page.setTitle('404');
+      Page.setTitle('304 - Redirecting');
       Page.setPage('error');
 
-      if($stateParams.page && $stateParams.id && $stateParams.url){
-        _ctrl.info = {page: $stateParams.page, id: $stateParams.id, url: $stateParams.url};
-      }
+      const processRedirect = () => {
+         $timeout(() => {
+           _ctrl.timeToRedirect--;
+           if(_ctrl.timeToRedirect == 0){
+             $window.location.href = _ctrl.pathToGoTo;
+           } else {
+             processRedirect();
+           }
+         },1000);
+       };
 
-      _ctrl.page = $stateParams.page;
-      
-      _ctrl.emailSubject = _ctrl.info ? 
-        'ICGC DCC /' + _ctrl.info.page  + '/' + _ctrl.info.id +' Page Not Found' : 
-        'ICGC DCC Page Not Found' ;
+       processRedirect();
     });
 })();

--- a/dcc-portal-ui/app/scripts/304/js/304.js
+++ b/dcc-portal-ui/app/scripts/304/js/304.js
@@ -40,7 +40,7 @@ angular.module('icgc.304', ['icgc.304.controllers', 'ui.router'])
       const processRedirect = () => {
          $timeout(() => {
            _ctrl.timeToRedirect--;
-           if(_ctrl.timeToRedirect == 0){
+           if(_ctrl.timeToRedirect === 0){
              $window.location.href = _ctrl.pathToGoTo;
            } else {
              processRedirect();

--- a/dcc-portal-ui/app/scripts/app/js/app.js
+++ b/dcc-portal-ui/app/scripts/app/js/app.js
@@ -256,7 +256,7 @@
     'icgc.historyManager',
     'icgc.survival',
     'icgc.404',
-    'icgc.304',
+    'icgc.301',
 
     // old
     'app.ui',
@@ -475,16 +475,15 @@
       // Setting the initial language to English CA.
       gettextCatalog.setCurrentLanguage('en_CA');
 
-      const redirect = _.find(REDIRECTS, (redirect) => redirect.from === $location.url());
-
       HistoryManager.addToIgnoreScrollResetWhiteList(['analysis','advanced', 'compound', 'dataRepositories', 'donor', 'beacon', 'project', 'gene']);
       
       $rootScope.$on('$stateChangeError', function(event, toState, toParams, fromState, fromParams, error) {
         if(error.status === 404) {
+          const redirect = _.find(REDIRECTS, (redirect) => redirect.from === $location.url());
           let state = '404', page = toState.name;
 
           if(redirect){
-            state = '304';
+            state = '301';
             page = redirect.to;
           }
       
@@ -496,10 +495,11 @@
       });
 
       $rootScope.$on('$stateNotFound', function() {
+        const redirect = _.find(REDIRECTS, (redirect) => redirect.from === $location.url());
         let  state = '404', page = '';
 
         if(redirect){
-          state = '304';
+          state = '301';
           page = redirect.to;
         }
         
@@ -615,7 +615,7 @@
       let state = '404', page = $location.url();
 
       if(redirect){
-        state = '304';
+        state = '301';
         page = redirect.to;
       }
 

--- a/dcc-portal-ui/app/scripts/app/js/app.js
+++ b/dcc-portal-ui/app/scripts/app/js/app.js
@@ -481,7 +481,7 @@
         if(error.status === 404) {
           const redirect = _.find(REDIRECTS, (redirect) => redirect.from === $location.path());
           let state = '404', page = toState.name;
-          debugger;
+
           if(redirect){
             state = '301';
             page = redirect.to;
@@ -497,7 +497,7 @@
       $rootScope.$on('$stateNotFound', function() {
         const redirect = _.find(REDIRECTS, (redirect) => redirect.from === $location.path());
         let  state = '404', page = '';
-        debugger;
+
         if(redirect){
           state = '301';
           page = redirect.to;

--- a/dcc-portal-ui/app/scripts/app/js/app.js
+++ b/dcc-portal-ui/app/scripts/app/js/app.js
@@ -495,7 +495,7 @@
         }
       });
 
-      $rootScope.$on('$stateNotFound', function(e) {
+      $rootScope.$on('$stateNotFound', function() {
         let  state = '404', page = '';
 
         if(redirect){

--- a/dcc-portal-ui/app/scripts/app/js/app.js
+++ b/dcc-portal-ui/app/scripts/app/js/app.js
@@ -479,9 +479,9 @@
       
       $rootScope.$on('$stateChangeError', function(event, toState, toParams, fromState, fromParams, error) {
         if(error.status === 404) {
-          const redirect = _.find(REDIRECTS, (redirect) => redirect.from === $location.url());
+          const redirect = _.find(REDIRECTS, (redirect) => redirect.from === $location.path());
           let state = '404', page = toState.name;
-
+          debugger;
           if(redirect){
             state = '301';
             page = redirect.to;
@@ -495,9 +495,9 @@
       });
 
       $rootScope.$on('$stateNotFound', function() {
-        const redirect = _.find(REDIRECTS, (redirect) => redirect.from === $location.url());
+        const redirect = _.find(REDIRECTS, (redirect) => redirect.from === $location.path());
         let  state = '404', page = '';
-
+        debugger;
         if(redirect){
           state = '301';
           page = redirect.to;
@@ -611,7 +611,7 @@
 
     // If invalid route is requested
     $urlRouterProvider.otherwise(function ($injector, $location){
-      const redirect = _.find(REDIRECTS, (redirect) => redirect.from === $location.url());
+      const redirect = _.find(REDIRECTS, (redirect) => redirect.from === $location.path());
       let state = '404', page = $location.url();
 
       if(redirect){

--- a/dcc-portal-ui/app/scripts/app/js/app.js
+++ b/dcc-portal-ui/app/scripts/app/js/app.js
@@ -587,7 +587,9 @@
 
     // If invalid route is requested
     $urlRouterProvider.otherwise(function ($injector, $location){
-      return '/404?page=' + $location.url();
+      $injector.invoke(['$state', function($state) {
+        $state.go('404', {page: $location.url()}, {location: false});
+      }]);
     });
 
     markedProvider.setOptions({ gfm: true });

--- a/dcc-portal-ui/app/scripts/index.js
+++ b/dcc-portal-ui/app/scripts/index.js
@@ -102,4 +102,5 @@ require('./pancancer/js/pancancer.js');
 require('./translations/js/translations.js');
 require('./entitysetupload/js/entitysetupload.js');
 require('./404/js/404.js');
+require('./304/js/304.js');
 

--- a/dcc-portal-ui/app/scripts/index.js
+++ b/dcc-portal-ui/app/scripts/index.js
@@ -102,5 +102,5 @@ require('./pancancer/js/pancancer.js');
 require('./translations/js/translations.js');
 require('./entitysetupload/js/entitysetupload.js');
 require('./404/js/404.js');
-require('./304/js/304.js');
+require('./301/js/301.js');
 


### PR DESCRIPTION
- Removed redirection functionality from 404
- New controller for redirection
- Using same template as 404
- Constant is being used in `app.js` to configure redirection URLs