### PR TITLE
Fix Genome Viewer not loading, and twice as many tracks showing up on navigation to another mutation

### DIFF
--- a/dcc-portal-ui/app/scripts/genomemaps/js/viewer.js
+++ b/dcc-portal-ui/app/scripts/genomemaps/js/viewer.js
@@ -491,6 +491,7 @@ angular.module('icgc.modules.genomeviewer').directive('gvembed', function (GMSer
 
       require.ensure([], require => {
         require('~/scripts/genome-viewer.js');
+        var region = attrs.region;
       function setup(regionObj) {
         regionObj.start = parseInt(regionObj.start, 10);
         regionObj.end = parseInt(regionObj.end, 10);
@@ -786,7 +787,11 @@ angular.module('icgc.modules.genomeviewer').directive('gvembed', function (GMSer
         }
       }
 
-      attrs.$observe('region', update);
+      attrs.$observe('region', function (newRegion) {
+        if (newRegion !== region) {
+          update();
+        }
+      });
       update();
 
       });

--- a/dcc-portal-ui/app/scripts/genomemaps/js/viewer.js
+++ b/dcc-portal-ui/app/scripts/genomemaps/js/viewer.js
@@ -640,6 +640,9 @@ angular.module('icgc.modules.genomeviewer').directive('gvembed', function (GMSer
             }
           }),
           dataAdapter: new IcgcGeneAdapter(defaultGeneAdapterOptions),
+          handlers: {
+            load: (isLoading) => !isLoading && scope.$apply(() => scope.isGvLoading = false),
+          },
         });
         genomeViewer.addTrack(tracks.icgcGeneTrack);
 
@@ -707,6 +710,9 @@ angular.module('icgc.modules.genomeviewer').directive('gvembed', function (GMSer
             }
           }),
           dataAdapter: new IcgcMutationAdapter(defaultMutationAdapterOptions),
+          handlers: {
+            load: (isLoading) => !isLoading && scope.$apply(() => scope.isGvLoading = false),
+          },
         });
 
         genomeViewer.addTrack(tracks.icgcMutationsTrack);

--- a/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-gene-track.js
+++ b/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-gene-track.js
@@ -24,9 +24,8 @@
 'use strict';
 
 function IcgcGeneTrack(args) {
-  Track.call(this, args);
   // Using Underscore 'extend' function to extend and add Backbone Events
-  _.extend(this, Backbone.Events);
+  Track.call(this, _.extend({}, Backbone.Events, args));
 
   //set default args
 

--- a/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-gene-track.js
+++ b/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-gene-track.js
@@ -42,6 +42,11 @@ function IcgcGeneTrack(args) {
 
 IcgcGeneTrack.prototype = new Track({});
 
+IcgcGeneTrack.prototype.setLoading = function (loadState) {
+  Track.prototype.setLoading.call(this, loadState);
+  this.trigger('load', loadState);
+};
+
 IcgcGeneTrack.prototype.updateHeight = function () {
   //this._updateHeight();
   if (this.histogram) {

--- a/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-mutation-track.js
+++ b/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-mutation-track.js
@@ -26,9 +26,8 @@
 IcgcMutationTrack.prototype = new Track({});
 
 function IcgcMutationTrack(args) {
-  Track.call(this, args);
   // Using Underscore 'extend' function to extend and add Backbone Events
-  _.extend(this, Backbone.Events);
+  Track.call(this, _.extend({}, Backbone.Events, args));
 
   //set default args
 

--- a/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-mutation-track.js
+++ b/dcc-portal-ui/app/vendor/scripts/genome-viewer/icgc-mutation-track.js
@@ -42,6 +42,10 @@ function IcgcMutationTrack(args) {
   _.extend(this, args);
 }
 
+IcgcMutationTrack.prototype.setLoading = function (loadState) {
+  Track.prototype.setLoading.call(this, loadState);
+  this.trigger('load', loadState);
+};
 
 IcgcMutationTrack.prototype.updateHeight = function () {
   //this._updateHeight();


### PR DESCRIPTION
Genome Viewer sometimes being stuck in the loading state on the mutations page sometimes is due to our Angular code not knowing when loading is complete. Data loading in GV is handled outside of Angular via direct calls to `jQuery.ajax`, which doesn't trigger the digest cycle. 

To fix this, the ICGC mutation and gene tracks [now fires a `'load'`](https://github.com/icgc-dcc/dcc-portal/pull/357/files#diff-3b45405d6e51480cb1fb07af932fd117R47) event whenever `setLoading` is called, and passes along the argument passed to `setLoading`. Caveat: `Backbone.Events` was not being properly extended. The methods needed to be passed to the call to `Track`'s constructor,  otherwise automated event listening (reading from `handlers` params) won't work, since it expects `this.on` to be Backbone.Event's `on` and is called inside `Track`'s constructor.

The bug with duplicate tracks showing up was due to `update()` (which calls `setup`） being called twice when navigating from one mutation page to another mutation page. 