### PR TITLE
IS NOT filter implementation

### DIFF
--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/pql/convert/JqlFiltersDeserializer.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/pql/convert/JqlFiltersDeserializer.java
@@ -105,7 +105,7 @@ public class JqlFiltersDeserializer extends JsonDeserializer<JqlFilters> {
 
         while(nodeChildFields.hasNext()) {
           val nodeChildField = nodeChildFields.next();
-          final JsonNodeFactory nodeFactory = JsonNodeFactory.instance;
+          val nodeFactory = JsonNodeFactory.instance;
           ObjectNode node = nodeFactory.objectNode();
           node.set(nodeChildField.getKey(), nodeChildField.getValue());
 
@@ -124,7 +124,6 @@ public class JqlFiltersDeserializer extends JsonDeserializer<JqlFilters> {
     }
 
     val typeFields = typeFieldsBuilder.build();
-
     return typeFields.isEmpty() ? emptyMap() : singletonMap(type, typeFields);
   }
 
@@ -206,7 +205,7 @@ public class JqlFiltersDeserializer extends JsonDeserializer<JqlFilters> {
 
   private static void validateOperation(JsonNode fieldValue) {
     log.debug("Validating operation for {}", fieldValue);
-    checkSemantic(fieldValue.size() <= 2, "More than one operation detected. %s", fieldValue);
+    checkSemantic(fieldValue.size() <= 2, "More than two operations detected. %s", fieldValue);
     val operation = getFirstFieldName(fieldValue);
     checkSemantic(Operation.operations().contains(operation), "Invalid operation '%s'", operation);
   }

--- a/dcc-portal-server/src/test/java/org/icgc/dcc/portal/server/pql/convert/Jql2PqlConverterTest.java
+++ b/dcc-portal-server/src/test/java/org/icgc/dcc/portal/server/pql/convert/Jql2PqlConverterTest.java
@@ -69,13 +69,12 @@ public class Jql2PqlConverterTest {
   }
 
   @Test
-  public void fieldsWithIsNotFilterTest() {
+  public void fieldsWithIsNotFilpostterTest() {
     val query = Query.builder()
             .fields(ImmutableList.of("id", "age"))
             .filters(new FiltersParam("{donor:{id:{is:['DO1', 'DO3'], not:['DO2']}}}").get())
             .build();
     assertResponse(query, "select(id,age),in(donor.id,'DO1','DO3'),not(in(donor.id,'DO2'))");
-
   }
 
   @Test

--- a/dcc-portal-server/src/test/java/org/icgc/dcc/portal/server/pql/convert/Jql2PqlConverterTest.java
+++ b/dcc-portal-server/src/test/java/org/icgc/dcc/portal/server/pql/convert/Jql2PqlConverterTest.java
@@ -69,6 +69,16 @@ public class Jql2PqlConverterTest {
   }
 
   @Test
+  public void fieldsWithIsNotFilterTest() {
+    val query = Query.builder()
+            .fields(ImmutableList.of("id", "age"))
+            .filters(new FiltersParam("{donor:{id:{is:['DO1', 'DO3'], not:['DO2']}}}").get())
+            .build();
+    assertResponse(query, "select(id,age),in(donor.id,'DO1','DO3'),not(in(donor.id,'DO2'))");
+
+  }
+
+  @Test
   public void allFieldsTest() {
     val query = Query.builder()
         .build();

--- a/dcc-portal-server/src/test/java/org/icgc/dcc/portal/server/pql/convert/JqlDeserializerTest.java
+++ b/dcc-portal-server/src/test/java/org/icgc/dcc/portal/server/pql/convert/JqlDeserializerTest.java
@@ -102,6 +102,35 @@ public class JqlDeserializerTest {
   }
 
   @Test
+  public void multiIdTest() {
+    val result = convert("{mutation:{id:{is:['MU123'], not:['MU109']}}}");
+    assertThat(result.getEntityValues().size()).isEqualTo(1);
+
+    val mutationValues = result.getEntityValues().get("mutation");
+    assertThat(mutationValues.size()).isEqualTo(2);
+
+    val is = Iterables.get(mutationValues, 0);
+    assertThat(is.getOperation()).isEqualTo(Operation.IS);
+
+    val isValue = Iterables.get(mutationValues, 0).getValue();
+    assertThat(isValue.isArray()).isTrue();
+
+    val isArrayValues = (JqlArrayValue) isValue;
+    assertThat(isArrayValues.get()).containsExactly("MU123");
+
+    val not = Iterables.get(mutationValues, 1);
+    assertThat(not.getOperation()).isEqualTo(Operation.NOT);
+
+    val notValue = Iterables.get(mutationValues, 1).getValue();
+    assertThat(notValue.isArray()).isTrue();
+
+    val notArrayValues = (JqlArrayValue) notValue;
+    assertThat(notArrayValues.get()).containsExactly("MU109");
+
+
+  }
+
+  @Test
   public void removeEmptyFilterValueTest() {
     assertThat(convert("{donor:{id:{is:[]}}}").getEntityValues()).isEmpty();
     assertThat(convert("{donor:{id:{is:''}}}").getEntityValues()).isEmpty();

--- a/dcc-portal-server/src/test/java/org/icgc/dcc/portal/server/pql/convert/JqlDeserializerTest.java
+++ b/dcc-portal-server/src/test/java/org/icgc/dcc/portal/server/pql/convert/JqlDeserializerTest.java
@@ -126,8 +126,6 @@ public class JqlDeserializerTest {
 
     val notArrayValues = (JqlArrayValue) notValue;
     assertThat(notArrayValues.get()).containsExactly("MU109");
-
-
   }
 
   @Test


### PR DESCRIPTION
- Renamed `parseType` to `parseNode`
- Moved `parseField` inside `parseNode`
- Added test on `JqlDeserializer` and `JQL2PQL` to check for IS NOT filter functionality