### PR TITLE
DCCPRTL-273 Unable to download saved sets when Item Type is 'Gene'

### DIFF
--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/repository/GeneRepository.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/repository/GeneRepository.java
@@ -165,7 +165,7 @@ public class GeneRepository implements Repository {
     val map = Maps.<String, String> newLinkedHashMap();
     for (val hit : response.getHits()) {
       String id = hit.getId();
-      String symbol = hit.getFields().get(symbolFieldName).getValue();
+      String symbol = hit.sourceAsMap().get(symbolFieldName).toString();
 
       map.put(id, symbol);
     }


### PR DESCRIPTION
Getting Gene Symbols from Source map instead of fields