### PR TITLE
[DCCPRTL-306] add coding facet to the portal

### DIFF
--- a/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/DonorCentricTypeModel.java
+++ b/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/DonorCentricTypeModel.java
@@ -69,7 +69,7 @@ public class DonorCentricTypeModel extends TypeModel {
       "projectName",
       "studies",
       "state",
-      "mutation.coding");
+      "mutation.genomic_region");
 
   private final static List<String> PUBLIC_FIELDS = ImmutableList.of(
       "id",
@@ -240,7 +240,7 @@ public class DonorCentricTypeModel extends TypeModel {
                 string("functional_impact_prediction_summary", "mutation.functionalImpact"))),
         string("mutation_type", "mutation.type"),
         nestedArrayOfObjects("observation", initObservation()),
-        bool("coding", "mutation.coding"));
+        bool("genomic_region", "mutation.genomic_region"));
   }
 
   private static ObjectFieldModel initObservation() {

--- a/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/DonorCentricTypeModel.java
+++ b/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/DonorCentricTypeModel.java
@@ -68,7 +68,8 @@ public class DonorCentricTypeModel extends TypeModel {
       "analysisTypes",
       "projectName",
       "studies",
-      "state");
+      "state",
+      "mutation.coding");
 
   private final static List<String> PUBLIC_FIELDS = ImmutableList.of(
       "id",
@@ -236,7 +237,8 @@ public class DonorCentricTypeModel extends TypeModel {
             "consequence",
             object(
                 string("consequence_type", "mutation.consequenceType"),
-                string("functional_impact_prediction_summary", "mutation.functionalImpact"))),
+                string("functional_impact_prediction_summary", "mutation.functionalImpact"),
+                bool("coding", "mutation.coding"))),
         string("mutation_type", "mutation.type"),
         nestedArrayOfObjects("observation", initObservation()));
   }

--- a/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/DonorCentricTypeModel.java
+++ b/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/DonorCentricTypeModel.java
@@ -237,10 +237,10 @@ public class DonorCentricTypeModel extends TypeModel {
             "consequence",
             object(
                 string("consequence_type", "mutation.consequenceType"),
-                string("functional_impact_prediction_summary", "mutation.functionalImpact"),
-                bool("coding", "mutation.coding"))),
+                string("functional_impact_prediction_summary", "mutation.functionalImpact"))),
         string("mutation_type", "mutation.type"),
-        nestedArrayOfObjects("observation", initObservation()));
+        nestedArrayOfObjects("observation", initObservation()),
+        bool("coding", "mutation.coding"));
   }
 
   private static ObjectFieldModel initObservation() {

--- a/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/GeneCentricTypeModel.java
+++ b/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/GeneCentricTypeModel.java
@@ -174,6 +174,7 @@ public class GeneCentricTypeModel extends TypeModel {
         string("chromosome", "mutation.chromosome"),
         long_("chromosome_end", "mutation.end"),
         long_("chromosome_start", "mutation.start"),
+        bool("coding", "mutation.coding"),
         defineConsequence(),
         defineObservation());
 
@@ -183,8 +184,7 @@ public class GeneCentricTypeModel extends TypeModel {
   private static ArrayFieldModel defineConsequence() {
     val element = object(
         string("consequence_type", "mutation.consequenceType"),
-        string("functional_impact_prediction_summary", "mutation.functionalImpact"),
-        bool("coding", "mutation.coding"));
+        string("functional_impact_prediction_summary", "mutation.functionalImpact"));
 
     return nestedArrayOfObjects("consequence", element);
   }

--- a/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/GeneCentricTypeModel.java
+++ b/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/GeneCentricTypeModel.java
@@ -24,6 +24,7 @@ import static org.dcc.portal.pql.meta.field.LongFieldModel.long_;
 import static org.dcc.portal.pql.meta.field.ObjectFieldModel.object;
 import static org.dcc.portal.pql.meta.field.StringFieldModel.identifiableString;
 import static org.dcc.portal.pql.meta.field.StringFieldModel.string;
+import static org.dcc.portal.pql.meta.field.BooleanFieldModel.bool;
 
 import java.util.List;
 import java.util.Map;
@@ -41,7 +42,7 @@ import lombok.val;
 public class GeneCentricTypeModel extends TypeModel {
 
   private final static String TYPE_PREFIX = "gene";
-  private static final List<String> AVAILABLE_FACETS = ImmutableList.of("type", "chromosome");
+  private static final List<String> AVAILABLE_FACETS = ImmutableList.of("type", "chromosome", "mutation.coding");
 
   // Including real fields, not aliases. Because after the AST is built by PqlParseTreeVisitor includes are resolved to
   // the real fields
@@ -182,7 +183,8 @@ public class GeneCentricTypeModel extends TypeModel {
   private static ArrayFieldModel defineConsequence() {
     val element = object(
         string("consequence_type", "mutation.consequenceType"),
-        string("functional_impact_prediction_summary", "mutation.functionalImpact"));
+        string("functional_impact_prediction_summary", "mutation.functionalImpact"),
+        bool("coding", "mutation.coding"));
 
     return nestedArrayOfObjects("consequence", element);
   }

--- a/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/GeneCentricTypeModel.java
+++ b/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/GeneCentricTypeModel.java
@@ -42,7 +42,7 @@ import lombok.val;
 public class GeneCentricTypeModel extends TypeModel {
 
   private final static String TYPE_PREFIX = "gene";
-  private static final List<String> AVAILABLE_FACETS = ImmutableList.of("type", "chromosome", "mutation.coding");
+  private static final List<String> AVAILABLE_FACETS = ImmutableList.of("type", "chromosome", "mutation.genomic_region");
 
   // Including real fields, not aliases. Because after the AST is built by PqlParseTreeVisitor includes are resolved to
   // the real fields
@@ -174,7 +174,7 @@ public class GeneCentricTypeModel extends TypeModel {
         string("chromosome", "mutation.chromosome"),
         long_("chromosome_end", "mutation.end"),
         long_("chromosome_start", "mutation.start"),
-        bool("coding", "mutation.coding"),
+        bool("genomic_region", "mutation.genomic_region"),
         defineConsequence(),
         defineObservation());
 

--- a/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/MutationCentricTypeModel.java
+++ b/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/MutationCentricTypeModel.java
@@ -125,6 +125,7 @@ public class MutationCentricTypeModel extends TypeModel {
         .add(string(MUTATION_LOCATION, MUTATION_LOCATION))
 
         .add(string(SCORE, ImmutableSet.of(SCORE, "affectedDonorCountFiltered")))
+        .add(bool("coding", "coding"))
         .build();
   }
 
@@ -142,8 +143,7 @@ public class MutationCentricTypeModel extends TypeModel {
             string("id", "transcriptId"),
             string("functional_impact_prediction_summary", "functionalImpact"),
             object("consequence",
-                string("consequence_type", "consequenceType"),
-                bool("coding", "coding")),
+                string("consequence_type", "consequenceType")),
             object("gene",
                 identifiableString("_gene_id", "gene.id"),
                 string("biotype", "gene.type"),

--- a/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/MutationCentricTypeModel.java
+++ b/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/MutationCentricTypeModel.java
@@ -23,6 +23,7 @@ import static org.dcc.portal.pql.meta.field.LongFieldModel.long_;
 import static org.dcc.portal.pql.meta.field.ObjectFieldModel.object;
 import static org.dcc.portal.pql.meta.field.StringFieldModel.identifiableString;
 import static org.dcc.portal.pql.meta.field.StringFieldModel.string;
+import static org.dcc.portal.pql.meta.field.BooleanFieldModel.bool;
 
 import java.util.List;
 import java.util.Map;
@@ -50,7 +51,8 @@ public class MutationCentricTypeModel extends TypeModel {
       "functionalImpact",
       "sequencingStrategy",
       "study",
-      "chromosome");
+      "chromosome",
+      "coding");
 
   private static final List<String> PUBLIC_FIELDS = ImmutableList.of(
       "id",
@@ -139,7 +141,9 @@ public class MutationCentricTypeModel extends TypeModel {
         object(
             string("id", "transcriptId"),
             string("functional_impact_prediction_summary", "functionalImpact"),
-            object("consequence", string("consequence_type", "consequenceType")),
+            object("consequence",
+                string("consequence_type", "consequenceType"),
+                bool("coding", "coding")),
             object("gene",
                 identifiableString("_gene_id", "gene.id"),
                 string("biotype", "gene.type"),

--- a/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/MutationCentricTypeModel.java
+++ b/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/MutationCentricTypeModel.java
@@ -52,7 +52,7 @@ public class MutationCentricTypeModel extends TypeModel {
       "sequencingStrategy",
       "study",
       "chromosome",
-      "coding");
+      "genomic_region");
 
   private static final List<String> PUBLIC_FIELDS = ImmutableList.of(
       "id",
@@ -125,7 +125,7 @@ public class MutationCentricTypeModel extends TypeModel {
         .add(string(MUTATION_LOCATION, MUTATION_LOCATION))
 
         .add(string(SCORE, ImmutableSet.of(SCORE, "affectedDonorCountFiltered")))
-        .add(bool("coding", "coding"))
+        .add(bool("genomic_region", "genomic_region"))
         .build();
   }
 

--- a/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/ObservationCentricTypeModel.java
+++ b/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/ObservationCentricTypeModel.java
@@ -44,7 +44,7 @@ public class ObservationCentricTypeModel extends TypeModel {
 
   private final static String TYPE_PREFIX = "observation";
   private static final List<String> INCLUDE_FIELDS =
-      ImmutableList.of("ssm.gene.consequence", "ssm.observation", "ssm.gene", "mutation.coding");
+      ImmutableList.of("ssm.gene.consequence", "ssm.observation", "ssm.gene", "mutation.genomic_region");
   private static final List<String> PUBLIC_FIELDS = ImmutableList.of(
       "chromosome",
       "donor.primarySite",
@@ -134,7 +134,7 @@ public class ObservationCentricTypeModel extends TypeModel {
         nestedArrayOfObjects("consequence", "consequences", object(
             string("consequence_type", "mutation.consequenceType"),
             string("functional_impact_prediction_summary", "mutation.functionalImpact"))),
-        bool("coding", "mutation.coding")
+        bool("genomic_region", "mutation.genomic_region")
         ));
   }
 

--- a/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/ObservationCentricTypeModel.java
+++ b/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/ObservationCentricTypeModel.java
@@ -25,6 +25,7 @@ import static org.dcc.portal.pql.meta.field.ObjectFieldModel.nestedObject;
 import static org.dcc.portal.pql.meta.field.ObjectFieldModel.object;
 import static org.dcc.portal.pql.meta.field.StringFieldModel.identifiableString;
 import static org.dcc.portal.pql.meta.field.StringFieldModel.string;
+import static org.dcc.portal.pql.meta.field.BooleanFieldModel.bool;
 
 import java.util.List;
 import java.util.Map;
@@ -43,7 +44,7 @@ public class ObservationCentricTypeModel extends TypeModel {
 
   private final static String TYPE_PREFIX = "observation";
   private static final List<String> INCLUDE_FIELDS =
-      ImmutableList.of("ssm.gene.consequence", "ssm.observation", "ssm.gene");
+      ImmutableList.of("ssm.gene.consequence", "ssm.observation", "ssm.gene", "mutation.coding");
   private static final List<String> PUBLIC_FIELDS = ImmutableList.of(
       "chromosome",
       "donor.primarySite",
@@ -132,7 +133,8 @@ public class ObservationCentricTypeModel extends TypeModel {
             arrayOfStrings("molecular_function")),
         nestedArrayOfObjects("consequence", "consequences", object(
             string("consequence_type", "mutation.consequenceType"),
-            string("functional_impact_prediction_summary", "mutation.functionalImpact")))
+            string("functional_impact_prediction_summary", "mutation.functionalImpact"),
+            bool("coding", "mutation.coding")))
         ));
   }
 

--- a/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/ObservationCentricTypeModel.java
+++ b/dcc-portal-pql/src/main/java/org/dcc/portal/pql/meta/ObservationCentricTypeModel.java
@@ -133,8 +133,8 @@ public class ObservationCentricTypeModel extends TypeModel {
             arrayOfStrings("molecular_function")),
         nestedArrayOfObjects("consequence", "consequences", object(
             string("consequence_type", "mutation.consequenceType"),
-            string("functional_impact_prediction_summary", "mutation.functionalImpact"),
-            bool("coding", "mutation.coding")))
+            string("functional_impact_prediction_summary", "mutation.functionalImpact"))),
+        bool("coding", "mutation.coding")
         ));
   }
 

--- a/dcc-portal-pql/src/test/java/org/dcc/portal/pql/ast/visitor/CreateEsAstVisitorTest.java
+++ b/dcc-portal-pql/src/test/java/org/dcc/portal/pql/ast/visitor/CreateEsAstVisitorTest.java
@@ -106,7 +106,7 @@ public class CreateEsAstVisitorTest {
 
     result = (AggregationsNode) visit(facetsAll());
     assertThat(((TermsAggregationNode) result.getChild(6)).getFieldName()).isEqualTo("ssm_occurrence.observation._study");
-    assertThat(result.childrenCount()).isEqualTo(8);
+    assertThat(result.childrenCount()).isEqualTo(9);
   }
 
   @Test

--- a/dcc-portal-ui/app/scripts/advanced/views/advanced.facets.mutations.html
+++ b/dcc-portal-ui/app/scripts/advanced/views/advanced.facets.mutations.html
@@ -21,6 +21,10 @@
         data-label="{{'Type' | translate}}"
         data-facet="AdvancedCtrl.Mutation.mutations.facets.type"></terms>
 
+    <terms data-type="mutation" data-facet-name="type" data-defined="true"
+           data-label="{{'Coding' | translate}}"
+           data-facet="AdvancedCtrl.Mutation.mutations.facets.coding"></terms>
+
     <terms data-type="mutation" data-facet-name="platform" data-collapsed="true"
         data-label="{{'Platform' | translate}}"
         data-facet="AdvancedCtrl.Mutation.mutations.facets.platform"></terms>

--- a/dcc-portal-ui/app/scripts/advanced/views/advanced.facets.mutations.html
+++ b/dcc-portal-ui/app/scripts/advanced/views/advanced.facets.mutations.html
@@ -21,8 +21,9 @@
         data-label="{{'Type' | translate}}"
         data-facet="AdvancedCtrl.Mutation.mutations.facets.type"></terms>
 
-    <terms data-type="mutation" data-facet-name="type" data-defined="true"
+    <terms data-type="mutation" data-facet-name="coding" data-defined="true"
            data-label="{{'Coding' | translate}}"
+           data-missing-text="{{'False' | translate}}"
            data-facet="AdvancedCtrl.Mutation.mutations.facets.coding"></terms>
 
     <terms data-type="mutation" data-facet-name="platform" data-collapsed="true"


### PR DESCRIPTION
in MutationCentricTypeModel, alias name is "coding"
in ObservationCentricTypeModel, the alias name is "mutation.coding"
in DonorCentricTypeModel, the alias name is "mutation.coding"
in GeneCentricTypeModel, the alias name is "mutation.coding"


the following is the path of "coding" field in different ES types:
mutation-centric: /coding
observation-centric: /ssm/gene/coding
gene-centric: /donor/ssm/coding
donor-centric: /gene/ssm/coding

