### PR TITLE
Enhancement: Added an endpoint at /v1/donors/pql to allow PQL queries…

### DIFF
--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/repository/OccurrenceRepository.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/repository/OccurrenceRepository.java
@@ -58,6 +58,7 @@ import static org.icgc.dcc.portal.server.util.SearchResponses.getTotalHitCount;
 
 import java.util.Map;
 
+import org.dcc.portal.pql.ast.StatementNode;
 import org.dcc.portal.pql.query.QueryEngine;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -149,6 +150,14 @@ public class OccurrenceRepository {
     log.debug("Response: {}", response);
 
     return response;
+  }
+
+
+  @NonNull
+  public SearchResponse findAllCentric(StatementNode pqlAst) {
+    val search = queryEngine.execute(pqlAst, OBSERVATION_CENTRIC);
+    log.debug("Request : {}", search.getRequestBuilder());
+    return search.getRequestBuilder().get();
   }
 
   public long count(Query query) {

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/Resource.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/Resource.java
@@ -69,6 +69,7 @@ public abstract class Resource {
    */
   protected static final String DEFAULT_FIELDS = "";
   protected static final String DEFAULT_FILTERS = "{}";
+  protected static final String DEFAULT_QUERY = "select(*)";
   protected static final String DEFAULT_TYPE = "tsv";
   protected static final String DEFAULT_FACETS = "true";
   protected static final String DEFAULT_SIZE = "10";
@@ -85,6 +86,7 @@ public abstract class Resource {
   /**
    * Logging template constants.
    */
+  protected static final String PQL_TEMPLATE = "PQL query = '{}'";
   protected static final String COUNT_TEMPLATE = "Request for a count of {} with filters '{}'";
   protected static final String FIND_ALL_TEMPLATE =
       "Request for '{}' {} from index '{}', sorted by '{}' in '{}' order with filters '{}'";

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/Resources.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/Resources.java
@@ -81,6 +81,8 @@ public final class Resources {
   public static final String API_FILTER_VALUE = "Filter the search results";
   public static final String API_TYPE_PARAM = "type";
   public static final String API_TYPE_VALUE = "Type of file export";
+  public static final String API_QUERY_VALUE = "PQL Query";
+  public static final String API_QUERY_PARAM = "query";
   public static final String API_SCORE_FILTERS_PARAM = "scoreFilters";
   public static final String API_SCORE_FILTER_VALUE = "Used to filter scoring differently from results";
   public static final String API_ANALYSIS_VALUE = "Analysis";

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/entity/DonorResource.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/entity/DonorResource.java
@@ -18,44 +18,7 @@
 package org.icgc.dcc.portal.server.resource.entity;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.icgc.dcc.portal.server.resource.Resources.AFFECTED_BY_THE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_DONOR_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_DONOR_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FACETS_ONLY_DESCRIPTION;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FACETS_ONLY_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FIELD_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FIELD_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FILTER_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FILTER_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FROM_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FROM_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_GENE_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_GENE_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_INCLUDE_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_INCLUDE_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_MUTATION_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_MUTATION_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_ORDER_ALLOW;
-import static org.icgc.dcc.portal.server.resource.Resources.API_ORDER_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_ORDER_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_SIZE_ALLOW;
-import static org.icgc.dcc.portal.server.resource.Resources.API_SIZE_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_SIZE_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_SORT_FIELD;
-import static org.icgc.dcc.portal.server.resource.Resources.API_SORT_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.DONOR;
-import static org.icgc.dcc.portal.server.resource.Resources.FIND_BY_ID;
-import static org.icgc.dcc.portal.server.resource.Resources.FIND_BY_ID_ERROR;
-import static org.icgc.dcc.portal.server.resource.Resources.FOR_THE;
-import static org.icgc.dcc.portal.server.resource.Resources.GENE;
-import static org.icgc.dcc.portal.server.resource.Resources.GROUPED_BY;
-import static org.icgc.dcc.portal.server.resource.Resources.MULTIPLE_IDS;
-import static org.icgc.dcc.portal.server.resource.Resources.MUTATION;
-import static org.icgc.dcc.portal.server.resource.Resources.NOT_FOUND;
-import static org.icgc.dcc.portal.server.resource.Resources.RETURNS_COUNT;
-import static org.icgc.dcc.portal.server.resource.Resources.RETURNS_LIST;
-import static org.icgc.dcc.portal.server.resource.Resources.S;
-import static org.icgc.dcc.portal.server.resource.Resources.TOTAL;
+import static org.icgc.dcc.portal.server.resource.Resources.*;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -130,6 +93,19 @@ public class DonorResource extends Resource {
     val query = query(fields, include, filters, from, size, sort, order);
 
     return donorService.findAllCentric(query, facetsOnly);
+  }
+
+  @GET
+  @Timed
+  @Path("/pql")
+  @ApiOperation(value = "String")
+  public String findPQL(
+      @ApiParam(value = API_QUERY_VALUE) @QueryParam(API_QUERY_PARAM) @DefaultValue(DEFAULT_QUERY) String pql
+  ) {
+
+    log.debug(PQL_TEMPLATE,  pql);
+
+    return donorService.findAllCentric(pql).toString();
   }
 
   @Path("/count")

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/entity/GeneResource.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/entity/GeneResource.java
@@ -18,47 +18,8 @@
 package org.icgc.dcc.portal.server.resource.entity;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.icgc.dcc.portal.server.resource.Resources.AFFECTED_BY_THE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_DONOR_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_DONOR_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FACETS_ONLY_DESCRIPTION;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FACETS_ONLY_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FIELD_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FIELD_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FILTER_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FILTER_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FROM_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FROM_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_GENE_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_GENE_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_INCLUDE_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_INCLUDE_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_MUTATION_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_MUTATION_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_ORDER_ALLOW;
-import static org.icgc.dcc.portal.server.resource.Resources.API_ORDER_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_ORDER_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_PROJECT_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_PROJECT_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_SIZE_ALLOW;
-import static org.icgc.dcc.portal.server.resource.Resources.API_SIZE_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_SIZE_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_SORT_FIELD;
-import static org.icgc.dcc.portal.server.resource.Resources.API_SORT_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.DONOR;
-import static org.icgc.dcc.portal.server.resource.Resources.FIND_BY_ID;
-import static org.icgc.dcc.portal.server.resource.Resources.FIND_BY_ID_ERROR;
-import static org.icgc.dcc.portal.server.resource.Resources.FOR_THE;
-import static org.icgc.dcc.portal.server.resource.Resources.GENE;
-import static org.icgc.dcc.portal.server.resource.Resources.GROUPED_BY;
-import static org.icgc.dcc.portal.server.resource.Resources.MULTIPLE_IDS;
-import static org.icgc.dcc.portal.server.resource.Resources.MUTATION;
-import static org.icgc.dcc.portal.server.resource.Resources.NOT_FOUND;
-import static org.icgc.dcc.portal.server.resource.Resources.PROJECT;
-import static org.icgc.dcc.portal.server.resource.Resources.RETURNS_COUNT;
-import static org.icgc.dcc.portal.server.resource.Resources.RETURNS_LIST;
-import static org.icgc.dcc.portal.server.resource.Resources.S;
-import static org.icgc.dcc.portal.server.resource.Resources.TOTAL;
+import static org.icgc.dcc.portal.server.resource.Resources.*;
+import static org.icgc.dcc.portal.server.resource.Resources.API_QUERY_PARAM;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -135,6 +96,19 @@ public class GeneResource extends Resource {
     val query = query(fields, include, filters, from, size, sort, order);
 
     return geneService.findAllCentric(query, facetsOnly);
+  }
+
+  @GET
+  @Timed
+  @Path("/pql")
+  @ApiOperation(value = "String")
+  public String findPQL(
+      @ApiParam(value = API_QUERY_VALUE) @QueryParam(API_QUERY_PARAM) @DefaultValue(DEFAULT_QUERY) String pql
+  ) {
+
+    log.debug(PQL_TEMPLATE,  pql);
+
+    return geneService.findAllCentric(pql).toString();
   }
 
   @Path("/count")

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/entity/MutationResource.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/entity/MutationResource.java
@@ -18,45 +18,8 @@
 package org.icgc.dcc.portal.server.resource.entity;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.icgc.dcc.portal.server.resource.Resources.AFFECTED_BY_THE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FACETS_ONLY_DESCRIPTION;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FACETS_ONLY_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FIELD_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FIELD_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FILTER_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FILTER_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FROM_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_FROM_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_GENE_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_GENE_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_INCLUDE_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_INCLUDE_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_MUTATION_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_MUTATION_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_ORDER_ALLOW;
-import static org.icgc.dcc.portal.server.resource.Resources.API_ORDER_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_ORDER_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_PROJECT_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_PROJECT_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_SIZE_ALLOW;
-import static org.icgc.dcc.portal.server.resource.Resources.API_SIZE_PARAM;
-import static org.icgc.dcc.portal.server.resource.Resources.API_SIZE_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.API_SORT_FIELD;
-import static org.icgc.dcc.portal.server.resource.Resources.API_SORT_VALUE;
-import static org.icgc.dcc.portal.server.resource.Resources.DONOR;
-import static org.icgc.dcc.portal.server.resource.Resources.FIND_BY_ID;
-import static org.icgc.dcc.portal.server.resource.Resources.FIND_BY_ID_ERROR;
-import static org.icgc.dcc.portal.server.resource.Resources.FOR_THE;
-import static org.icgc.dcc.portal.server.resource.Resources.GENE;
-import static org.icgc.dcc.portal.server.resource.Resources.GROUPED_BY;
-import static org.icgc.dcc.portal.server.resource.Resources.MULTIPLE_IDS;
-import static org.icgc.dcc.portal.server.resource.Resources.MUTATION;
-import static org.icgc.dcc.portal.server.resource.Resources.NOT_FOUND;
-import static org.icgc.dcc.portal.server.resource.Resources.PROJECT;
-import static org.icgc.dcc.portal.server.resource.Resources.RETURNS_COUNT;
-import static org.icgc.dcc.portal.server.resource.Resources.RETURNS_LIST;
-import static org.icgc.dcc.portal.server.resource.Resources.S;
-import static org.icgc.dcc.portal.server.resource.Resources.TOTAL;
+import static org.icgc.dcc.portal.server.resource.Resources.*;
+import static org.icgc.dcc.portal.server.resource.Resources.API_QUERY_PARAM;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -130,6 +93,19 @@ public class MutationResource extends Resource {
     log.debug(FIND_ALL_TEMPLATE, new Object[] { size, MUTATION, from, sort, order, filters });
     val query = query(fields, include, filters, from, size, sort, order);
     return mutationService.findAllCentric(query, facetsOnly);
+  }
+
+  @GET
+  @Timed
+  @Path("/pql")
+  @ApiOperation(value = "String")
+  public String findPQL(
+      @ApiParam(value = API_QUERY_VALUE) @QueryParam(API_QUERY_PARAM) @DefaultValue(DEFAULT_QUERY) String pql
+  ) {
+
+    log.debug(PQL_TEMPLATE,  pql);
+
+    return mutationService.findAllCentric(pql).toString();
   }
 
   @Path("/count")

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/entity/OccurrenceResource.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/entity/OccurrenceResource.java
@@ -68,6 +68,19 @@ public class OccurrenceResource extends Resource {
 
   }
 
+  @GET
+  @Timed
+  @Path("/pql")
+  @ApiOperation(value = "String")
+  public String findPQL(
+      @ApiParam(value = API_QUERY_VALUE) @QueryParam(API_QUERY_PARAM) @DefaultValue(DEFAULT_QUERY) String pql
+  ) {
+
+    log.debug(PQL_TEMPLATE,  pql);
+
+    return occurrenceService.findAllCentric(pql).toString();
+  }
+
   @Path("/count")
   @GET
   @Timed

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/service/DonorService.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/service/DonorService.java
@@ -137,15 +137,27 @@ public class DonorService {
     return findAllCentric(query, false);
   }
 
+  public SearchResponse findAllCentric(String pql) {
+    return donorRepository.findAllCentric(parse(pql));
+  }
+
+  @NonNull
+  public Donors findAllCentric(Query query, String pql) {
+    log.debug("PQL of findAllCentric is: {}", pql);
+    return buildDonors(findAllCentric(pql), query);
+  }
+
+  public String getPQL(Query query, boolean facetsOnly) {
+    return facetsOnly ?
+        QUERY_CONVERTER.convertCount(query, DONOR_CENTRIC) :
+        QUERY_CONVERTER.convert(query, DONOR_CENTRIC);
+  }
+
   @NonNull
   public Donors findAllCentric(Query query, boolean facetsOnly) {
-    val pql =
-        facetsOnly ? QUERY_CONVERTER.convertCount(query, DONOR_CENTRIC) : QUERY_CONVERTER.convert(query, DONOR_CENTRIC);
-    log.debug("PQL of findAllCentric is: {}", pql);
+    val pql = getPQL(query, facetsOnly);
 
-    val pqlAst = parse(pql);
-
-    return buildDonors(donorRepository.findAllCentric(pqlAst), query);
+    return findAllCentric(query, pql);
   }
 
   @NonNull

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/service/GeneService.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/service/GeneService.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.elasticsearch.action.search.MultiSearchResponse;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.SearchHit;
 import org.icgc.dcc.portal.server.model.EntityType;
 import org.icgc.dcc.portal.server.model.Gene;
@@ -245,6 +246,11 @@ public class GeneService {
     genes.setPagination(Pagination.of(hits.getHits().length, hits.getTotalHits(), query));
 
     return genes;
+  }
+
+  @NonNull
+  public SearchResponse findAllCentric(String pql) {
+    return geneRepository.findAllCentric(parse(pql));
   }
 
   public long count(Query query) {

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/service/MutationService.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/service/MutationService.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.elasticsearch.action.search.MultiSearchResponse;
+import org.elasticsearch.action.search.SearchResponse;
 import org.icgc.dcc.common.core.util.stream.Collectors;
 import org.icgc.dcc.portal.server.model.EntityType;
 import org.icgc.dcc.portal.server.model.Mutation;
@@ -83,6 +84,10 @@ public class MutationService {
     mutations.setPagination(Pagination.of(hits.getHits().length, hits.getTotalHits(), query));
 
     return mutations;
+  }
+
+  public SearchResponse findAllCentric(String pql) {
+    return mutationRepository.findAllCentric(parse(pql));
   }
 
   public Mutations findMutationsByDonor(Query query, String donorId) {

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/service/OccurrenceService.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/service/OccurrenceService.java
@@ -17,10 +17,12 @@
 
 package org.icgc.dcc.portal.server.service;
 
+import static org.dcc.portal.pql.query.PqlParser.parse;
 import static org.icgc.dcc.portal.server.util.ElasticsearchResponseUtils.createResponseMap;
 
 import java.util.Map;
 
+import org.elasticsearch.action.search.SearchResponse;
 import org.icgc.dcc.portal.server.model.EntityType;
 import org.icgc.dcc.portal.server.model.Occurrence;
 import org.icgc.dcc.portal.server.model.Occurrences;
@@ -56,6 +58,12 @@ public class OccurrenceService {
 
     return occurrences;
   }
+
+  public SearchResponse findAllCentric(String pql) {
+    return occurrenceRepository.findAllCentric(parse(pql));
+  }
+
+
 
   public long count(Query query) {
     return occurrenceRepository.count(query);


### PR DESCRIPTION
…. It uses the same API as /v1/donors, except that the filters parameter takes a PQL string.

Change: Just make the pql endpoint have one parameter, called "query", which
takes PQL as input and returns JSON as output.
Issue: From the swagger page, running a pql query 'select(*)' gets results, but 'select(*),limit(1)' doesn't.

Enhancement: Added endpoints for pql for mutations, occurances, and genes, as well as for donors

Code Cleanup: Removed unused import

Bugfix: Don't commit config files with valid tokens in them.

Bugfix: Don't commit test scripts that use the yml files, either.