### PR TITLE
One attempt at handling corner case of icgc storage manifest

### DIFF
--- a/dcc-portal-ui/app/scripts/repository/js/repository.js
+++ b/dcc-portal-ui/app/scripts/repository/js/repository.js
@@ -458,6 +458,7 @@ import './file-finder';
     $scope.createManifestId = function (repoName, repoData) {
 
       repoData.isGeneratingManifestID = true;
+      $scope.isGeneratingManifestID = true;
       repoData.manifestID = false;
 
       var selectedFiles = $scope.selectedFiles;
@@ -481,7 +482,9 @@ import './file-finder';
           throw new Error('No Manifest UUID is returned from API call.');
         }
         repoData.isGeneratingManifestID = false;
+        $scope.isGeneratingManifestID = false;
         repoData.manifestID = id;
+        $scope.manifestID = id;
      });
     };
 

--- a/dcc-portal-ui/app/scripts/repository/views/repository.external.submit.html
+++ b/dcc-portal-ui/app/scripts/repository/views/repository.external.submit.html
@@ -105,8 +105,6 @@
            </tr>
 
             <tr class="extras" data-ng-repeat-end>
-              <td colspan="6" class="text-right">
-             </td>
            </tr>
 
            <tr class="dndPlaceholder">
@@ -238,6 +236,8 @@
         </div>
       </div>
       <a
+      data-ng-repeat="repoData in repos"
+      data-ng-if="repos.length === 1 && repoData.hasManifest"
       href="http://docs.icgc.org/cloud/guide/#installation"
       target="_blank"
       style="margin-left: 4px;"

--- a/dcc-portal-ui/app/scripts/repository/views/repository.external.submit.html
+++ b/dcc-portal-ui/app/scripts/repository/views/repository.external.submit.html
@@ -104,91 +104,8 @@
 
            </tr>
 
-            <tr class="extras" data-ng-repeat-end data-ng-if="
-              repoData.isGeneratingManifestID ||
-              repoData.isGeneratingManifestShortUrl ||
-              repoData.manifestID ||
-              repoData.shortUrl"
-            >
+            <tr class="extras" data-ng-repeat-end>
               <td colspan="6" class="text-right">
-                <div class="spinner-container" data-ng-if="repoData.isGeneratingManifestShortUrl || repoData.isGeneratingManifestID">
-                  <i class="icon-spinner icon-spin"></i>
-                </div>
-
-                <div class="container-fluid">
-
-                  <div class="row" data-ng-if="repoData.shortUrl">
-                    <div class="col-sm-3">
-                      <translate>Manifest URL</translate>
-                    </div>
-                    <div class="col-sm-9 text-left">
-                      <input
-                        onClick="this.select()"
-                        size="18"
-                        type="text"
-                        value="{{repoData.shortUrl}}"
-                      />
-                      <span
-                          class="clip-icon"
-                          style="cursor: pointer;"
-                          data-copy-to-clip
-                          data-copy-data="repoData.shortUrl"
-                          data-show-copy-tips="true"
-                          data-prompt-on-copy="false"
-                          data-on-copy-success-message="{{'Copied!' | translate}}"
-                          data-on-hover-message="{{'Copy icgc-get ID to clipboard' | translate}}"
-                        >
-                          <span class="icon-clippy"></span>
-                      </span>
-                    </div>
-                  </div>
-
-                  <div class="row" data-ng-if-start="repoData.manifestID">
-                    <div class="col-sm-3">
-                      <translate>Manifest ID</translate>
-                    </div>
-                    <div class="col-md-5 text-left">
-                      
-                      <div class="manifest" data-ng-if="repoData.hasManifest">
-                        <div class="input-group clipboard-group">
-                          <input
-                            class="manifest-id form-control input-sm code text-center"
-                            onClick="this.select()"
-                            size="38"
-                            type="text"
-                            value="{{repoData.manifestID}}"
-                          />
-                          <span class="input-group-btn">
-                            <button class="btn btn-default btn-sm" type="button"
-                                data-copy-to-clip
-                                data-copy-data="repoData.manifestID"
-                                data-show-copy-tips="true"
-                                data-prompt-on-copy="false"
-                                data-on-copy-success-message="{{'Copied!' | translate}}"
-                                data-on-hover-message="{{'Copy to clipboard' | translate}}"
-                                >
-                                <i class="icon-clippy"></i>
-                            </button>
-                            
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div class="row" data-ng-if-end>
-                    <div class="col-sm-3">
-                      <translate>Usage example</translate>
-                    </div>
-                    <div class="col-sm-9 text-left">
-                      <code class="inline-code">
-                        {{ 'bin/icgc-storage-client manifest --manifest ' + repoData.manifestID }}
-                      </code>
-                    </div>
-                  </div>
-
-                </div>
-
              </td>
            </tr>
 
@@ -208,6 +125,8 @@
     </div>
 
     <div class="modal-footer">
+
+      <!-- ICGC-GET -->
       <button
         ng-if="!icgcGetId"
         class="t_button no-animate"
@@ -268,6 +187,68 @@
           icgc-tooltip="{{'<div class=\'tooltip-contents\'>icgc-get is a universal download client for accessing ICGC data residing in various data repositories. <br/><small><em>Click to see the User Guide for more information</em> <i class=\'fa fa-external-link\'></i></small></div>' | translate}}"
         ></i>
       </a>
+
+      <!-- ICGC Storage Manifest ID -->
+      <button
+        class="t_button"
+        data-ng-repeat="repoData in repos"
+        data-ng-if="repos.length === 1 && repoData.hasManifest && !manifestID"
+        data-ng-click="track('create-manifest-id', { action: 'click', label: repoData.repoName }); (!repoData.manifestID && !repoData.isGeneratingManifestID) && createManifestId(repoData.repoName, repoData)"
+      >
+        <span ng-show="!isGeneratingManifestID && !manifestID">
+          <translate>Manifest ID</translate>
+        </span>
+        <span ng-show="isGeneratingManifestID">
+          <translate>Generating Manifest ID</translate> <i class="fa fa-spin fa-spinner"></i>
+        </span>
+      </button>
+      </a>
+      <div ng-if="manifestID" class="text-left">
+        <span class="button-label">Your manifest ID is:</span>
+        <div class="flex-row align-flex-end">
+          <button
+            class="t_button icgc-get-id"
+            data-ng-click="
+              track('copy-manifest-id', { action: 'click' });
+            "
+            data-copy-to-clip
+            data-copy-analytics-tag="icgc-manifest-id"
+            data-copy-data="manifestID"
+            data-show-copy-tips="true"
+            data-prompt-on-copy="false"
+            data-on-copy-success-message="Copied!"
+            data-on-hover-message="Copy to clipboard"
+          >
+              {{ manifestID }}
+          </button>
+          <button
+              style="border-radius: 0 3px 3px 0;"
+              class="btn btn-default btn-sm"
+              type="button"
+              data-copy-to-clip
+              data-copy-analytics-tag="icgc-get-manifest-id"
+              data-copy-data="icgcGetId"
+              data-show-copy-tips="true"
+              data-prompt-on-copy="false"
+              data-on-copy-success-message="Copied!"
+              data-on-hover-message="Copy to clipboard"
+          >
+              <i class="icon-clippy"></i>
+          </button>
+        </div>
+      </div>
+      <a
+      href="http://docs.icgc.org/cloud/guide/#installation"
+      target="_blank"
+      style="margin-left: 4px;"
+      >
+        <i
+          class="fa fa-question-circle"
+          style="cursor: pointer;"
+          icgc-tooltip="{{'<div class=\'tooltip-contents\'>A manifest ID can be used by the ICGC Storage client. <br/><small><em>Click to see the User Guide for more information</em> <i class=\'fa fa-external-link\'></i></small></div>' | translate}}"
+        ></i>
+      </a>
+
       <button
         class="t_button"
         ng-click="
@@ -275,7 +256,7 @@
           track('generate-manifest', { action: 'click' });
         "
       >
-        <i class="icon-download"></i><translate>Generate Manifest</translate>
+        <i class="icon-download"></i><translate>Download Manifest</translate>
       </button>
       <a
         href="http://docs.icgc.org/cloud/guide/#manifest-command"
@@ -289,49 +270,35 @@
         ></i>
       </a>
       
-      <button
-        class="t_button"
-        data-ng-repeat="repoData in repos"
-        data-ng-if="repos.length === 1 && repoData.hasManifest"
-        data-ng-disabled="repoData.manifestID || repoData.isGeneratingManifestID"
-        data-ng-click="track('create-manifest-id', { action: 'click', label: repoData.repoName }); (!repoData.manifestID && !repoData.isGeneratingManifestID) && createManifestId(repoData.repoName, repoData)"
-      >
-        <translate>Manifest ID</translate>
-      </button>
     </div>
-    <div class="more-info" ng-if="icgcGetId">
+
+    <div class="more-info" data-ng-if="manifestID">
       <div>
-        <!--
-        Your file selection icgc-get manifest ID is:
-        <div class="input-group clipboard-group" ng-if="icgcGetId">
-          <input
-            class="manifest-id form-control input-sm code text-center"
-            onClick="this.select() || track('icgc-get-id', { action: 'click' })"
-            size="38"
-            type="text"
-            value="{{icgcGetId}}"
-          >
-          <span class="input-group-btn">
-            <button
-                class="btn btn-default btn-sm"
-                type="button"
-                data-copy-to-clip
-                data-copy-analytics-tag="icgc-get-manifest-id"
-                data-copy-data="icgcGetId"
-                data-show-copy-tips="true"
-                data-prompt-on-copy="false"
-                data-on-copy-success-message="Copied!"
-                data-on-hover-message="Copy to clipboard"
-                >
-                <i class="icon-clippy"></i>
-            </button>
-          </span>
+        <div>
+          <translate>For downloading files only from AWS-Virginia or Collaboratory, you can use the ICGC Storage Client:</translate>
+        </div>
+        <code
+          ng-class="{ 'text-center': isGeneratingManifestID }"
+          class="code"
+          data-copy-to-clip
+          data-copy-analytics-tag="generate-manifest-id"
+          data-copy-data="'bin/icgc-storage-client manifest --manifest ' + manifestID"
+          data-show-copy-tips="true"
+          data-prompt-on-copy="false"
+          data-on-copy-success-message="Copied!"
+          data-on-hover-message="Copy to clipboard"
+        >
+          <span>bin/icgc-storage-client manifest --manifest {{manifestID}}</span>
           <i
             class="icon-spin icon-spinner"
-            ng-class="{ 'hidden': !isGeneratingIcgcGetId }"
+            ng-class="{ 'hidden': !isGeneratingManifestID }"
           ></i>
-        </div>
-        -->
+        </code>
+      </div>
+    </div>
+
+    <div class="more-info" ng-if="icgcGetId">
+      <div>
         <div>
           <translate>To download your current file selection, execute the following command:</translate>
         </div>

--- a/dcc-portal-ui/app/scripts/repository/views/repository.external.submit.html
+++ b/dcc-portal-ui/app/scripts/repository/views/repository.external.submit.html
@@ -249,6 +249,7 @@
         ></i>
       </a>
 
+      <!-- MANIFEST DOWNLOAD -->
       <button
         class="t_button"
         ng-click="


### PR DESCRIPTION
I discovered a pretty jarring corner case when selecting only AWS or Collab as the repos. A new button appears for generating a manifest ID and a usage example with icgc-storage. My opinion would be to simply remove the button. In the event we want to keep it, this is one possible way to handle it. 

Behavior mirrors that of the icgc-get @cheapsteak implemented. 

## Before:
![screen shot 2017-10-30 at 2 47 58 pm](https://user-images.githubusercontent.com/6350043/32193864-f6b410c8-bd8e-11e7-978b-8eddcd09b687.png)

## After:
![screen shot 2017-10-30 at 4 22 31 pm](https://user-images.githubusercontent.com/6350043/32193887-0caef7a8-bd8f-11e7-8b09-345915ed2bff.png)
