### PR TITLE
[DCCPRTL-336] Add Show PQL Button and PQLApi Service

### DIFF
--- a/dcc-portal-ui/app/scripts/app/js/app.js
+++ b/dcc-portal-ui/app/scripts/app/js/app.js
@@ -227,6 +227,7 @@
     // new
     'icgc.ui',
     'icgc.share',
+    'icgc.pql',
     'icgc.facets',
     'icgc.projects',
     'icgc.donors',

--- a/dcc-portal-ui/app/scripts/facets/views/current.html
+++ b/dcc-portal-ui/app/scripts/facets/views/current.html
@@ -5,6 +5,7 @@
                 <i class="icon-undo"></i>
             </button>
             <share-button></share-button>
+            <pql-button></pql-button>
         </li>
         <li data-ng-repeat="(typeName, type) in filters">
             <ul>

--- a/dcc-portal-ui/app/scripts/index.js
+++ b/dcc-portal-ui/app/scripts/index.js
@@ -22,6 +22,7 @@ require('./common/js/pcawg.js');
 require('./common/js/translator.js');
 require('./common/js/abridger.js');
 require('./share/js/share.js');
+require('./pql/js/pql.js');
 require('./ui/js/directives.js');
 require('./ui/js/tpls.js');
 require('./ui/js/suggest.js');

--- a/dcc-portal-ui/app/scripts/pql/js/pql.js
+++ b/dcc-portal-ui/app/scripts/pql/js/pql.js
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2016(c) The Ontario Institute for Cancer Research. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the terms of the GNU Public
+ * License v3.0. You should have received a copy of the GNU General Public License along with this
+ * program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+require('./pql.scss');
+
+(function () {
+  'use strict';
+
+  var module = angular.module('icgc.pql', []);
+
+  module.directive('pqlButton', function () {
+    return {
+      restrict: 'E',
+      replace: true,
+      transclude: true,
+      templateUrl: '/scripts/pql/views/pql.html',
+      controller: 'pqlCtrl as pqlCtrl',
+      link: function ($scope) {
+        $scope.entityType = 'page';
+      }
+    };
+  });
+
+  module.service('PQLApi', function ($state, $location, $log, FilterService, Restangular) {
+    /**
+     * parsePaginationParams(entityName)
+     * Will pull the query fields from the current page URL and parse
+     * out the values for 'sort', 'order', 'from', and 'size' currently displayed
+     * 
+     * param entityName: one of ['donors', 'genes', 'mutations']
+     * 
+     * return Object, all fields optional: {sort, order, from, size}
+     */
+    function parsePaginationParams(entityName) {
+      const output = {};
+      
+      const urlQueryParams = $location.search();
+      const entityParamString = urlQueryParams[entityName];
+      if (entityParamString) {
+        try {
+          const params = JSON.parse(entityParamString);
+
+          if (params.hasOwnProperty('size')) {
+            output.size = params.size;
+          }
+          if (params.hasOwnProperty('from')) {
+            output.from = params.from;
+          }
+          if (params.hasOwnProperty('order')) {
+            output.order = params.order;
+          }
+          if (params.hasOwnProperty('sort')) {
+            output.sort = params.sort;
+          }
+  
+        } catch (e) {
+          $log.warn(`Provided URL Query string is invalid JSON: ${queryString}`);
+        }
+      }
+      return output;
+    }
+
+    /**
+     * PQLService.getPQL()
+     * Fetch from server the PQL syntax statement that corresponds with the current page,
+     * including all filters, sorting, and pagination parameters
+     * 
+     * return: Promise with result of Restangular request to get PQL
+     */
+    this.getPQL = function () {
+
+      const filters = FilterService.filters();
+      const params = {
+        queryType: 'DONOR_CENTRIC',
+        size: 10,
+        from: 1,
+        order: 'desc',
+        filters: filters,
+      };
+
+      const searchTab = $state.current.data.tab;
+      switch(searchTab) {
+        case 'gene':
+        params.queryType='GENE_CENTRIC';
+        _.merge(params, parsePaginationParams('donors'));
+        break;
+        case 'mutation':
+        params.queryType='MUTATION_CENTRIC';
+        _.merge(params, parsePaginationParams('mutations'));
+        break;
+        
+        // donor is intentional fall-through to default
+        // Default getPQL to use DONOR_CENTRIC if unspecified
+        case 'donor':
+        default:
+          params.queryType='DONOR_CENTRIC';
+          _.merge(params, parsePaginationParams('donors'));
+          break;
+      }
+
+      return Restangular.all('PQL').get('', params);
+    };
+
+  });
+
+  module.controller('pqlCtrl', function ($scope, $element, PQLApi, FilterService) {
+    var _ctrl = this;
+    this.query = '';
+    this.changedUrl = true;
+    _ctrl.toggle = function (opt) {
+      _ctrl.active = opt;
+    };
+    this.popoverIsOpen = false;
+
+    this.handleClickShowPQLButton = () => {
+      PQLApi.getPQL()
+        .then((data) => {
+          this.query = data.PQL ? data.PQL : '';
+        });
+    };
+    
+    const bodyClickListener = function (e) {
+      jQuery($element).each(function () {
+        if ((!jQuery(this).is(e.target) && jQuery(this).has(e.target).length === 0 && jQuery('.popover').has(e.target).length === 0)) {
+          _ctrl.popoverIsOpen = false;
+        }
+      });
+    };
+
+    jQuery('body').on('click', bodyClickListener);
+    $scope.$on('$destroy', () => {
+      jQuery('body').off('click', bodyClickListener);
+    });
+  });
+
+})();

--- a/dcc-portal-ui/app/scripts/pql/js/pql.js
+++ b/dcc-portal-ui/app/scripts/pql/js/pql.js
@@ -95,7 +95,7 @@ require('./pql.scss');
       switch(searchTab) {
         case 'gene':
         params.queryType='GENE_CENTRIC';
-        _.merge(params, parsePaginationParams('donors'));
+        _.merge(params, parsePaginationParams('genes'));
         break;
         case 'mutation':
         params.queryType='MUTATION_CENTRIC';

--- a/dcc-portal-ui/app/scripts/pql/js/pql.scss
+++ b/dcc-portal-ui/app/scripts/pql/js/pql.scss
@@ -1,0 +1,28 @@
+.pql-popover-content{
+    max-width:500px;
+}
+
+.pql-popover{
+
+    .loading-text{
+        font-size: 14px;
+        margin: 0px;
+        font-weight: normal;
+        line-height: 225%;
+        color: #666a6a;
+    }
+    .loading{
+        font-size: 14px;
+    }
+    .input-block-level{
+        font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+        font-size: 12px;
+        padding: 4px;
+        width: 93%;
+        resize: vertical;
+    }
+    .icon-clippy{
+        font-size: x-large;
+    }
+    
+}

--- a/dcc-portal-ui/app/scripts/pql/views/pql.html
+++ b/dcc-portal-ui/app/scripts/pql/views/pql.html
@@ -1,0 +1,15 @@
+<span style="display: inline-block;">
+  <button
+  type="button"
+  class="t_button  t_current__remove_all"
+  popover-title="PQL Query"
+  popover-template = "'/scripts/pql/views/pql.popup.html'" 
+  popover-placement = "bottom"
+  popover-is-open = "pqlCtrl.popoverIsOpen"
+  popover-animation="false"
+  popover-class="pql-popover-content"
+  ng-click = "pqlCtrl.handleClickShowPQLButton()"
+  >
+    <translate>Show PQL</translate>
+  </button>
+</span>

--- a/dcc-portal-ui/app/scripts/pql/views/pql.popup.html
+++ b/dcc-portal-ui/app/scripts/pql/views/pql.popup.html
@@ -1,0 +1,39 @@
+  <div class="pql-popover" style="width:500px;padding-bottom:0">
+    <div id="inputBox">
+      <textarea id="pqlQueryHolder"
+      ng-if="pqlCtrl.query"
+      class="pql-query-holder input-block-level" 
+      rows="5"
+      cols="40"
+      readonly
+      >{{pqlCtrl.query}}</textarea>
+      <span
+      ng-if="pqlCtrl.query"
+      class="clip-icon"
+      data-copy-to-clip
+      data-copy-data="pqlCtrl.query"
+      data-show-copy-tips="true"
+      data-prompt-on-copy="false"
+      data-on-hover-message="{{'Click to copy' | translate}}"
+      data-on-copy-success-message="{{'PQL Query copied!' | translate}}"
+      data-on-copy-focus-on="#shortURLInput"
+      >
+        <span class="icon-clippy"></span>
+      </span>
+
+      
+      <span 
+      ng-if="!pqlCtrl.query"
+      class="loading loading-icon">
+        <i class="icon-spinner icon-spin"></i>
+      </span>
+      <small
+      ng-if="!pqlCtrl.query"
+      class="loading-text"
+      >
+        <translate>Loading...</translate>
+      </small>
+    </div>
+  </div>
+
+  

--- a/dcc-portal-ui/app/scripts/share/js/share.js
+++ b/dcc-portal-ui/app/scripts/share/js/share.js
@@ -141,16 +141,16 @@ require('./share.scss');
     };
 
     const bodyClickListener = function (e) {
-      $($element).each(function () {
-        if ((!$(this).is(e.target) && $(this).has(e.target).length === 0 && $('.popover').has(e.target).length === 0)) {
+      jQuery($element).each(function () {
+        if ((!jQuery(this).is(e.target) && jQuery(this).has(e.target).length === 0 && jQuery('.popover').has(e.target).length === 0)) {
           _ctrl.popoverIsOpen = false;
         }
       });
     };
 
-    $('body').on('click', bodyClickListener);
+    jQuery('body').on('click', bodyClickListener);
     $scope.$on('$destroy', () => {
-      $('body').off('click', bodyClickListener);
+      jQuery('body').off('click', bodyClickListener);
     });
   });
 })();

--- a/dcc-portal-ui/app/scripts/share/js/share.scss
+++ b/dcc-portal-ui/app/scripts/share/js/share.scss
@@ -17,6 +17,9 @@
         font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
         font-size: 12px;
         padding:4px;
-
+        width:100%;
+    }
+    .icon-clippy{
+        font-size:x-large;
     }
 }

--- a/dcc-portal-ui/app/scripts/share/views/share.html
+++ b/dcc-portal-ui/app/scripts/share/views/share.html
@@ -1,14 +1,14 @@
 <span style="display: inline-block;">
-    <button
-        type="button"
-        class="t_button  t_current__remove_all"
-        popover-title="Share Link"
-        popover-template = "'/scripts/share/views/share.popup.html'" 
-        popover-placement = "bottom"
-        popover-is-open = "shareCtrl.popoverIsOpen"
-        popover-animation="false"
-        ng-click = "shareCtrl.handleClickShareButton(shareParams)"
-    >
-        <i class="icon-share"></i> <translate>Share</translate>
-    </button>
+  <button
+  type="button"
+  class="t_button  t_current__remove_all"
+  popover-title="Share Link"
+  popover-template = "'/scripts/share/views/share.popup.html'" 
+  popover-placement = "bottom"
+  popover-is-open = "shareCtrl.popoverIsOpen"
+  popover-animation="false"
+  ng-click = "shareCtrl.handleClickShareButton(shareParams)"
+  >
+    <i class="icon-share"></i> <translate>Share</translate>
+  </button>
 </span>

--- a/dcc-portal-ui/app/scripts/share/views/share.popup.html
+++ b/dcc-portal-ui/app/scripts/share/views/share.popup.html
@@ -2,13 +2,28 @@
   <div class="share-popover" style="width:195px;padding-bottom:0">
     <small class="input-header"><translate>Link to this {{entityType}}:</translate></small>
     <div id="inputBox">
-    </div>
-    <input id="shortURLInput" 
+
+      <input id="shortURLInput" 
+        ng-if="!shareCtrl.changedUrl"
+        class="short-url-input input-block-level" 
+        type="text" 
+        value={{shareCtrl.shortUrl}} 
+      />
+      <span
       ng-if="!shareCtrl.changedUrl"
-      class="short-url-input input-block-level" 
-      type="text" 
-      value={{shareCtrl.shortUrl}} 
-    />
+      class="clip-icon"
+      data-copy-to-clip
+      data-copy-data="shareCtrl.shortUrl"
+      data-show-copy-tips="true"
+      data-prompt-on-copy="false"
+      data-on-hover-message="{{'Click to copy' | translate}}"
+      data-on-copy-success-message="{{'Share Link copied!' | translate}}"
+      data-on-copy-focus-on="#shortURLInput"
+      >
+      <span class="icon-clippy"></span>
+    </span>
+
+    
     <span 
       ng-if="shareCtrl.changedUrl"
       class="loading loading-icon">
@@ -17,21 +32,8 @@
     <small
       ng-if="shareCtrl.changedUrl"
       class="loading-text"
-    >Loading...</small>
-    
-    <span
-       ng-if="!shareCtrl.changedUrl"
-       class="clip-icon"
-       data-copy-to-clip
-       data-copy-data="shareCtrl.shortUrl"
-       data-show-copy-tips="true"
-       data-prompt-on-copy="false"
-       data-on-hover-message="{{'Click to copy' | translate}}"
-       data-on-copy-success-message="{{'Share Link copied!' | translate}}"
-       data-on-copy-focus-on="#shortURLInput"
-    >
-    <span class="icon-clippy"></span>
-    </span>
+    ><translate>Loading...</translate></small>
+    </div>
   </div>
 
   


### PR DESCRIPTION
PQLApi Service provides a method to pull the filter and pagination properties from the current view and call the newly created RESTful API /PQL service. This grants the UI the ability to convert the current search view into a PQL syntax query statement.

A 'Show PQL' button was added to the advanced search bar. This was built to match the 'Share' button. It uses popover to show the results and implements a loading view while waiting for the PQL Api Service to return the PQL query.

https://jira.oicr.on.ca/browse/DCCPRTL-336