### PR TITLE
Ignoring Integration Tests

### DIFF
--- a/dcc-portal-server/src/test/java/org/icgc/dcc/portal/server/repository/DonorRepositoryIntegrationTest.java
+++ b/dcc-portal-server/src/test/java/org/icgc/dcc/portal/server/repository/DonorRepositoryIntegrationTest.java
@@ -19,12 +19,14 @@ package org.icgc.dcc.portal.server.repository;
 
 import org.icgc.dcc.portal.server.model.EntityType;
 import org.icgc.dcc.portal.server.model.IndexType;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 
 import com.carrotsearch.randomizedtesting.RandomizedRunner;
 
+@Ignore
 @RunWith(RandomizedRunner.class)
 public class DonorRepositoryIntegrationTest extends BaseRepositoryIntegrationTest {
 

--- a/dcc-portal-server/src/test/java/org/icgc/dcc/portal/server/repository/GeneRepositoryIntegrationTest.java
+++ b/dcc-portal-server/src/test/java/org/icgc/dcc/portal/server/repository/GeneRepositoryIntegrationTest.java
@@ -19,11 +19,13 @@ package org.icgc.dcc.portal.server.repository;
 
 import org.icgc.dcc.portal.server.model.EntityType;
 import org.icgc.dcc.portal.server.model.IndexType;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.runners.MockitoJUnitRunner;
 
+@Ignore
 @RunWith(MockitoJUnitRunner.class)
 public class GeneRepositoryIntegrationTest extends BaseRepositoryIntegrationTest {
 

--- a/dcc-portal-server/src/test/java/org/icgc/dcc/portal/server/repository/MutationRepositoryIntegrationTest.java
+++ b/dcc-portal-server/src/test/java/org/icgc/dcc/portal/server/repository/MutationRepositoryIntegrationTest.java
@@ -19,11 +19,13 @@ package org.icgc.dcc.portal.server.repository;
 
 import org.icgc.dcc.portal.server.model.EntityType;
 import org.icgc.dcc.portal.server.model.IndexType;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.runners.MockitoJUnitRunner;
 
+@Ignore
 @RunWith(MockitoJUnitRunner.class)
 public class MutationRepositoryIntegrationTest extends BaseRepositoryIntegrationTest {
 

--- a/dcc-portal-server/src/test/java/org/icgc/dcc/portal/server/repository/OccurrenceRepositoryIntegrationTest.java
+++ b/dcc-portal-server/src/test/java/org/icgc/dcc/portal/server/repository/OccurrenceRepositoryIntegrationTest.java
@@ -24,11 +24,13 @@ import org.elasticsearch.action.search.MultiSearchResponse;
 import org.icgc.dcc.portal.server.model.Query.QueryBuilder;
 import org.icgc.dcc.portal.server.model.IndexType;
 import org.icgc.dcc.portal.server.model.param.FiltersParam;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.runners.MockitoJUnitRunner;
 
+@Ignore
 @RunWith(MockitoJUnitRunner.class)
 public class OccurrenceRepositoryIntegrationTest extends BaseRepositoryIntegrationTest {
 

--- a/dcc-portal-server/src/test/java/org/icgc/dcc/portal/server/security/oauth/OAuthClientIntegrationTest.java
+++ b/dcc-portal-server/src/test/java/org/icgc/dcc/portal/server/security/oauth/OAuthClientIntegrationTest.java
@@ -31,10 +31,12 @@ import org.icgc.dcc.portal.server.model.AccessToken;
 import org.icgc.dcc.portal.server.security.oauth.OAuthClient;
 import org.icgc.dcc.portal.server.service.BadRequestException;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.common.base.Strings;
 
+@Ignore
 public class OAuthClientIntegrationTest {
 
   private static final String SERVICE_URL = "http://localhost:8443";


### PR DESCRIPTION
Remove: Legacy Integration Tests #464

Tested these changes on ES 5.6.4 / 5.6.7 (common) branch, all remaining tests pass consistently (even some that failed before). Appears to have been an issue specific to Linux (debian based) before 5.3.1 (https://github.com/elastic/elasticsearch/issues/23218).

The remaining ignored integration tests can probably be completely removed.