### PR TITLE
removed assumption username=email

### DIFF
--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/security/AuthResource.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/security/AuthResource.java
@@ -149,7 +149,9 @@ public class AuthResource extends Resource {
 
       val userType = resolveUserType(cudToken, cmsToken);
       val userId = icgcUser.getUserName();
-      val userEmail = userType == UserType.CUD ? icgcUser.getEmail() : icgcUser.getUserName();
+      // always get email regardless of user type
+      // fix for: extsd.oicr.on.ca/browse/ICGCSD-1390
+      val userEmail = icgcUser.getEmail();
 
       val dccUser = createUser(userType, userId, userEmail, token);
       val verifiedResponse = verifiedResponse(dccUser);


### PR DESCRIPTION
Portal code assumed that username and email addresses of any person signing in with OpenId is same. This works for most of the users but there are users with different usernames than their email. If those users login with OpenId then portal shows a red icon for their DACO and Cloud access even if they have these permissions.