### PR TITLE
Disabled error banner for login related error

### DIFF
--- a/dcc-portal-ui/app/scripts/app/js/app.js
+++ b/dcc-portal-ui/app/scripts/app/js/app.js
@@ -547,8 +547,14 @@ module.run(function(
     }
 
     if (response.status === 500) {
-      Notify.setParams(response);
-      Notify.showErrors();
+      // don't show login errors
+      var url = response.config && response.config && response.config.url ? response.config.url : '';
+      if(url.includes('/auth/verify'))
+        console.error(response);
+      else {
+        Notify.setParams(response);
+        Notify.showErrors();
+      }
     } else if (response.status === 404) {
       console.error(response.data.message);
     }

--- a/dcc-portal-ui/app/scripts/app/js/app.js
+++ b/dcc-portal-ui/app/scripts/app/js/app.js
@@ -548,10 +548,11 @@ module.run(function(
 
     if (response.status === 500) {
       // don't show login errors
-      var url = response.config && response.config && response.config.url ? response.config.url : '';
-      if(url.includes('/auth/verify'))
+      var url = (response.config || {}).url || '';
+
+      if (url.includes('/auth/verify')) {
         console.error(response);
-      else {
+      } else {
         Notify.setParams(response);
         Notify.showErrors();
       }


### PR DESCRIPTION
Disabling error banner for login related errors - as these errors don't affect user's ability to browse the portal. So showing these errors are sort of misleading - as user may interpret that he/she can not/ should not browser the portal because of this error. 

Such errors are now only logged to console.