### PR TITLE
Update banner for Collab open access

### DIFF
--- a/dcc-portal-server/src/main/resources/application.yml
+++ b/dcc-portal-server/src/main/resources/application.yml
@@ -200,7 +200,7 @@ jupyter:
   url: "https://jupyterhub.cancercollaboratory.org"
 
 banner:
-  message: "Documentation for downloading PCAWG datasets is now available."
+  message: "The Cancer Genome Collaboratory is now open to all researchers."
   alwaysShow: false
-  link: "https://docs.icgc.org/pcawg/data/"
-  linkText: "Click here to go to doc site."
+  link: "https://cancercollaboratory.org/"
+  linkText: "Learn about this compute cloud resource here."


### PR DESCRIPTION
Updated banner:
(1) Remove existing, old message about PCAWG documentation
(2) Add new message about opening up Collab access and provide link to Collab homepage