### PR TITLE
Fix/dccprtl 564 update pcawg links and policy

### DIFF
--- a/dcc-portal-ui/app/scripts/pancancer/views/pancancer.html
+++ b/dcc-portal-ui/app/scripts/pancancer/views/pancancer.html
@@ -128,8 +128,7 @@
     </translate>
     <translate>
         Hence, scientific works with a primary focus on pan-cancer (across entity) analysis 
-        that made use of the WGS pan cancer community resource will be under publication embargo until the WGS 
-        pan-cancer consortium publishes its main paper (anticipated June 2016).
+        that made use of the WGS pan cancer community resource will be under publication embargo until the WGS pan-cancer consortium publishes its main paper or July 25, 2019, whichever occurs first.
     </translate>
     <translate>
         Methodology papers may be published prior to this embargo, with agreement from the full scientific working group.

--- a/dcc-portal-ui/app/scripts/pancancer/views/pancancer.html
+++ b/dcc-portal-ui/app/scripts/pancancer/views/pancancer.html
@@ -128,7 +128,7 @@
     </translate>
     <translate>
         Hence, scientific works with a primary focus on pan-cancer (across entity) analysis 
-        that made use of the WGS pan cancer community resource will be under publication embargo until the WGS pan-cancer consortium publishes its main paper or July 25, 2019, whichever occurs first.
+        that made use of the WGS pan cancer community resource will be under publication embargo until the WGS pan-cancer consortium publishes its marker paper or until July 25, 2019, whichever is earlier.
     </translate>
     <translate>
         Methodology papers may be published prior to this embargo, with agreement from the full scientific working group.

--- a/dcc-portal-ui/app/scripts/releases/views/home.html
+++ b/dcc-portal-ui/app/scripts/releases/views/home.html
@@ -102,7 +102,7 @@
         <div class="content-wrap">
             <div class="intro">
                 <div>
-                    <a class="logo-link" href="https://docs.icgc.org/pcawg/" target="_blank">
+                    <a class="logo-link" href="https://dcc.icgc.org/pcawg" target="_blank">
                         <img src="/styles/images/PCAWG-final.svg" />
                     </a>
                     <h2>
@@ -110,7 +110,7 @@
                     </h2>
                     <p>
                         <translate>The
-                            <a href="https://docs.icgc.org/pcawg/" target="_blank">Pan-Cancer Analysis of Whole Genomes</a> is an international collaboration from over 700 scientists
+                            <a href="https://dcc.icgc.org/pcawg" target="_blank">Pan-Cancer Analysis of Whole Genomes</a> is an international collaboration from over 700 scientists
                             to identify common mutation patterns across more than 60 cancer types. </translate>
                     </p>
                     <div class="cta">


### PR DESCRIPTION
Minor changes to fix incorrect linkouts to the PCAWG page and update the PCAWG embargo policy.

Original issue: #564 